### PR TITLE
Fixes ori-edge/k8s_gateway#8 (rename incorrectly reused "resources")

### DIFF
--- a/charts/k8s-gateway/templates/configmap.yaml
+++ b/charts/k8s-gateway/templates/configmap.yaml
@@ -16,8 +16,8 @@ data:
         k8s_gateway "{{ required "Delegated domain ('domain') is mandatory " .Values.domain }}" {
           apex {{ .Values.apex }}
           ttl {{ .Values.ttl }}
-          {{- if gt (len .Values.resources) 0 }}
-          resources {{ join " " .Values.resources }}
+          {{- if gt (len .Values.watchedResources) 0 }}
+          resources {{ join " " .Values.watchedResources }}
           {{- end }}
         }
         prometheus 0.0.0.0:9153

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -14,8 +14,11 @@ apex: "dns"
 # TTL for non-apex responses (in seconds)
 ttl: 300
 
-# Limit what kind of resources to watch, e.g. resources: ["Ingress"]
+# Resources (CPU, memory etc)
 resources: []
+
+# Limit what kind of resources to watch, e.g. resources: ["Ingress"]
+watchedResources: []
 
 serviceAccount:
   create: true

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -17,7 +17,7 @@ ttl: 300
 # Resources (CPU, memory etc)
 resources: []
 
-# Limit what kind of resources to watch, e.g. resources: ["Ingress"]
+# Limit what kind of resources to watch, e.g. watchedResources: ["Ingress"]
 watchedResources: []
 
 serviceAccount:


### PR DESCRIPTION
Incorrectly reused value in Helm chart has been renamed