### PR TITLE
chart: Add nodeport and nodeSelector support

### DIFF
--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.1.0
 maintainers:
 - email: michae@ori.co

--- a/charts/k8s-gateway/README.md
+++ b/charts/k8s-gateway/README.md
@@ -1,2 +1,28 @@
 # k8s-gateway
 A simple chart to install [k8s_gateway](https://github.com/ori-edge/k8s_gateway)
+
+
+## Parameters
+
+The following table lists the configurable parameters of the k8s_gateway chart and their default values.
+
+| Parameter                        | Description                                                                               | Default               |
+| -------------------------------- | ----------------------------------------------------------------------------------------- | --------------------- |
+| `domain`                         | Delegated domain                                                                          |                       |
+| `watchedResources`               | Limit what kind of resources to watch, e.g. `watchedResources: ["Ingress"]`               | `[]`                  |
+| `ttl`                            | TTL for non-apex responses (in seconds)                                                   | `300`                 |
+| `dnsChallenge.enabled`           | Optional configuration option for DNS01 challenge                                         | `false`               |
+| `dnsChallenge.domain`            | See: https://cert-manager.io/docs/configuration/acme/dns01/                               | `dns01.clouddns.com`  |
+| `image.registry`                 | Image registry                                                                            | `quay.io`             |
+| `image.repository`               | Image repository                                                                          | `oriedge/k8s_gateway` |
+| `image.tag`                      | Image tag                                                                                 | `latest`              |
+| `image.pullPolicy`               | Image pull policy                                                                         | `Always`              |
+| `nodeSelector`                   | Node labels for pod assignment                                                            | `{}`                  |
+| `affinity`                       | Pod affinity                                                                              | `{}`                  |
+| `resources`                      | Pod resource requests & limits                                                            | `{}`                  |
+| `serviceAccount.create`          | Create ServiceAccount                                                                     | `true`                |
+| `serviceAccount.annotations`     | ServiceAccount annotations                                                                |                       |
+| `service.port`                   | Service port to expose                                                                    | `53`                  |
+| `service.type`                   | The type of service to create (`LoadBalancer`, `NodePort`)                                | `LoadBalancer`        |
+| `service.nodePort`               | Node port when service type is `NodePort`. Randomly chonsen by Kubernetes if not provided |                       |
+| `service.loadBalancerIP`         | The IP address to use when using serviceType `LoadBalancer`                               |                       |

--- a/charts/k8s-gateway/templates/deployment.yaml
+++ b/charts/k8s-gateway/templates/deployment.yaml
@@ -52,3 +52,11 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/k8s-gateway/templates/service.yaml
+++ b/charts/k8s-gateway/templates/service.yaml
@@ -18,3 +18,6 @@ spec:
     {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
+    {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+    loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+    {{- end }}

--- a/charts/k8s-gateway/templates/service.yaml
+++ b/charts/k8s-gateway/templates/service.yaml
@@ -10,6 +10,11 @@ metadata:
 spec:
   selector:
     {{- include "k8s-gateway.selectorLabels" . | nindent 6 }}
+  type: {{ .Values.service.type }}
   ports:
-  - {port: 53, protocol: UDP, name: udp-53}
-  type: LoadBalancer
+  - port: {{ .Values.service.port }}
+    protocol: UDP
+    name: udp-53
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -12,7 +12,7 @@ domain: ""
 ttl: 300
 
 # Resources (CPU, memory etc)
-resources:
+resources: {}
 
 # Limit what kind of resources to watch, e.g. watchedResources: ["Ingress"]
 watchedResources: []
@@ -32,7 +32,7 @@ dnsChallenge:
 
 serviceAccount:
   create: true
-  name:
+  name: ""
 
 service:
   type: LoadBalancer

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -33,10 +33,13 @@ dnsChallenge:
 serviceAccount:
   create: true
   name: ""
+  annotations: {}
 
 service:
   type: LoadBalancer
   port: 53
+  # nodePort: 30053
+  # loadBalancerIP: 192.168.1.2
 
 nodeSelector: {}
 

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -34,6 +34,10 @@ serviceAccount:
   create: true
   name:
 
+service:
+  type: LoadBalancer
+  port: 53
+
 nodeSelector: {}
 
 affinity: {}

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -33,3 +33,7 @@ dnsChallenge:
 serviceAccount:
   create: true
   name:
+
+nodeSelector: {}
+
+affinity: {}


### PR DESCRIPTION
Support deploying as NodePort service on specific node

At the time I didn't know k8s_gateway only resolves type: LoadBalancer services and that only type: LoadBalancer get service status.loadbalancer.ip field populated. After deploying k8s_gateway I ended up deploying metallb and will likely go back to using type: LoadBalancer.
Also it turns out type: LoadBalancer was already working by default in k3s with https://github.com/k3s-io/klipper-lb.

But nonetheless this PR correctly adds support for nodePort that I'm currently using :+1: 