### PR TITLE
Add support for overriding the hostname with annotations

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	defaultResyncPeriod  = 0
-	ingressHostnameIndex = "ingressHostname"
-	serviceHostnameIndex = "serviceHostname"
+	defaultResyncPeriod   = 0
+	ingressHostnameIndex  = "ingressHostname"
+	serviceHostnameIndex  = "serviceHostname"
+	hostnameAnnotationKey = "coredns.io/hostname"
 )
 
 // KubeController stores the current runtime configuration and cache
@@ -161,6 +162,10 @@ func serviceHostnameIndexFunc(obj interface{}) ([]string, error) {
 	}
 
 	hostname := service.Name + "." + service.Namespace
+	if annotation, exists := service.Annotations[hostnameAnnotationKey]; exists {
+		hostname = annotation
+	}
+
 	log.Debugf("Adding index %s for service %s", hostname, service.Name)
 
 	return []string{hostname}, nil

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -151,6 +151,25 @@ var testServices = map[string]*core.Service{
 			},
 		},
 	},
+	"annotation": {
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc3",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				"coredns.io/hostname": "annotation",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.3"},
+				},
+			},
+		},
+	},
 }
 
 var testBadServices = map[string]*core.Service{


### PR DESCRIPTION
Where the following service declaration would be exposed as `nginx.default.example.com`, with this PR it would be exposed as `web.example.com` (assuming the configured zone is example.com).

```yaml
kind: Service
apiVersion: v1
metadata:
  name: nginx
  annotations:
    coredns.io/hostname: web
spec:
  type: LoadBalancer
  ports:
    - port: 80
  selector:
    app: nginx
```