### PR TITLE
Add support for external cluster with kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ k8s_gateway ZONE
     ttl TTL
     apex APEX
     secondary SECONDARY
+    kubeconfig KUBECONFIG [CONTEXT]
 }
 ```
 
@@ -59,6 +60,7 @@ k8s_gateway ZONE
 * `ttl` can be used to override the default TTL value of 60 seconds.
 * `apex` can be used to override the default apex record value of `{ReleaseName}-k8s-gateway.{Namespace}`
 * `secondary` can be used to specify the optional apex record value of a peer nameserver running in the cluster (see `Dual Nameserver Deployment` section below).
+* `kubeconfig` can be used to connect to a remote Kubernetes cluster using a kubeconfig file. `CONTEXT` is optional, if not set, then the current context specified in kubeconfig will be used. It supports TLS, username and password, or token-based authentication.
 
 Example: 
 
@@ -68,6 +70,7 @@ k8s_gateway example.com {
     ttl 30
     apex exdns-1-k8s-gateway.kube-system
     secondary exdns-2-k8s-gateway.kube-system
+    kubeconfig /.kube/config
 }
 ```
 

--- a/gateway.go
+++ b/gateway.go
@@ -46,6 +46,8 @@ type Gateway struct {
 	apex             string
 	hostmaster       string
 	secondNS         string
+	configFile       string
+	configContext    string
 	ExternalAddrFunc func(request.Request) []dns.RR
 }
 

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -93,23 +94,38 @@ func (ctrl *KubeController) HasSynced() bool {
 }
 
 // RunKubeController kicks off the k8s controllers
-func RunKubeController(ctx context.Context) (*KubeController, error) {
-	config, err := rest.InClusterConfig()
+func (gw *Gateway) RunKubeController(ctx context.Context) error {
+	config, err := gw.getClientConfig()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	ctrl := newKubeController(ctx, kubeClient)
+	gw.Controller = newKubeController(ctx, kubeClient)
+	go gw.Controller.run()
 
-	go ctrl.run()
+	return nil
 
-	return ctrl, nil
+}
 
+func (gw *Gateway) getClientConfig() (*rest.Config, error) {
+	if gw.configFile != "" {
+		overrides := &clientcmd.ConfigOverrides{}
+		overrides.CurrentContext = gw.configContext
+
+		config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: gw.configFile},
+			overrides,
+		)
+
+		return config.ClientConfig()
+	}
+
+	return rest.InClusterConfig()
 }
 
 func ingressLister(ctx context.Context, c kubernetes.Interface, ns string) func(meta.ListOptions) (runtime.Object, error) {

--- a/setup.go
+++ b/setup.go
@@ -26,7 +26,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error(thisPlugin, err)
 	}
 
-	gw.Controller, err = RunKubeController(context.Background())
+	err = gw.RunKubeController(context.Background())
 	if err != nil {
 		return plugin.Error(thisPlugin, err)
 	}
@@ -91,6 +91,15 @@ func parse(c *caddy.Controller) (*Gateway, error) {
 					return nil, c.ArgErr()
 				}
 				gw.apex = args[0]
+			case "kubeconfig":
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return nil, c.ArgErr()
+				}
+				gw.configFile = args[0]
+				if len(args) == 2 {
+					gw.configContext = args[1]
+				}
 			default:
 				return nil, c.Errf("Unknown property '%s'", c.Val())
 			}


### PR DESCRIPTION
This allows you to configure a path for a `kubeconfig` to communicate with an external Kubernetes cluster.

```
.:53 {
    k8s_gateway example.org {
        kubeconfig /config
    }
}
```

Probably needs some tests, but works just fine.

Fixes #12