### PR TITLE
charts: service: move loadBalancerIP from port to top level of spec

### DIFF
--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.1.4
 maintainers:
 - email: michae@ori.co

--- a/charts/k8s-gateway/templates/service.yaml
+++ b/charts/k8s-gateway/templates/service.yaml
@@ -11,13 +11,13 @@ spec:
   selector:
     {{- include "k8s-gateway.selectorLabels" . | nindent 6 }}
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - port: {{ .Values.service.port }}
     protocol: UDP
     name: udp-53
     {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
     nodePort: {{ .Values.service.nodePort }}
-    {{- end }}
-    {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
-    loadBalancerIP: {{ .Values.service.loadBalancerIP }}
     {{- end }}


### PR DESCRIPTION
The `loadBalancerIP` setting should be at the same level as
`type: LoadBalancer`, not in the per-port settings.