### PR TITLE
Fix arm64 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,13 @@
-FROM golang:1.14.4 as builder
-
-ARG LDFLAGS
-
-WORKDIR /build
-
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-COPY cmd/ cmd/
-COPY *.go ./
-
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags "${LDFLAGS}" -o coredns cmd/coredns.go
-
 FROM debian:stable-slim
 
 RUN apt-get update && apt-get -uy upgrade
 RUN apt-get -y install ca-certificates && update-ca-certificates
 
 FROM scratch
+ARG ARCH
 
 COPY --from=0 /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder /build/coredns .
+ADD coredns-$ARCH /coredns
 
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
Was getting exec format error. I looked at how coredns does it in #25 - it looks easier to cross-compile by setting `GOARCH` rather than using buildx and qemu. Not sure why qemu wasn't building correct arm64 image.

- I changed `make build` to compile `coredns-amd64` and `coredns-arm64`
- I changed `make docker` to build ${IMG}:${COMMIT}-${ARCH}
- I added `make push` to push images and create multi-arch manifest ${IMG}:${COMMIT}
- Need to re-add `make release`.

docker image runs on both amd64 and arm64 nodes in my k8s cluster. Pushed to https://hub.docker.com/repository/docker/morganchristiansson/k8s_gateway