### PR TITLE
Add fall through support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ k8s_gateway ZONE
     apex APEX
     secondary SECONDARY
     kubeconfig KUBECONFIG [CONTEXT]
+    fallthrough [ZONES...]
 }
 ```
 
@@ -61,6 +62,7 @@ k8s_gateway ZONE
 * `apex` can be used to override the default apex record value of `{ReleaseName}-k8s-gateway.{Namespace}`
 * `secondary` can be used to specify the optional apex record value of a peer nameserver running in the cluster (see `Dual Nameserver Deployment` section below).
 * `kubeconfig` can be used to connect to a remote Kubernetes cluster using a kubeconfig file. `CONTEXT` is optional, if not set, then the current context specified in kubeconfig will be used. It supports TLS, username and password, or token-based authentication.
+* `fallthrough` if zone matches and no record can be generated, pass request to the next plugin. If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for those zones will be subject to fallthrough.
 
 Example: 
 

--- a/gateway.go
+++ b/gateway.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"
 )
@@ -49,6 +50,8 @@ type Gateway struct {
 	configFile       string
 	configContext    string
 	ExternalAddrFunc func(request.Request) []dns.RR
+
+	Fall fall.F
 }
 
 func newGateway() *Gateway {
@@ -142,7 +145,12 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	m := new(dns.Msg)
 	m.SetReply(state.Req)
 
+	// If there's no match, fall through or return NXDOMAIN
 	if len(addrs) == 0 {
+		if gw.Fall.Through(qname) {
+			return plugin.NextOrFailure(gw.Name(), gw.Next, ctx, w, r)
+		}
+
 		m.Rcode = dns.RcodeNameError
 		m.Ns = []dns.RR{gw.soa(state)}
 		if err := w.WriteMsg(m); err != nil {
@@ -161,8 +169,12 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		m.Ns = []dns.RR{gw.soa(state)}
 	}
 
-	// If there's no match, return the SOA
+	// If there's no match, fall through or return the SOA
 	if len(m.Answer) == 0 {
+		if gw.Fall.Through(qname) {
+			return plugin.NextOrFailure(gw.Name(), gw.Next, ctx, w, r)
+		}
+
 		m.Ns = []dns.RR{gw.soa(state)}
 	}
 

--- a/setup.go
+++ b/setup.go
@@ -58,6 +58,8 @@ func parse(c *caddy.Controller) (*Gateway, error) {
 
 		for c.NextBlock() {
 			switch c.Val() {
+			case "fallthrough":
+				gw.Fall.SetZonesFromArgs(c.RemainingArgs())
 			case "secondary":
 				args := c.RemainingArgs()
 				if len(args) == 0 {


### PR DESCRIPTION
This adds support for the `fallthrough` CoreDNS option which allows other plugins a chance to respond if `k8s_gateway` can't provide an answer.

Example use case:

```
.:53 {
    errors
    log
    ready
    k8s_gateway example.com {
        fallthrough
    }
    forward . /etc/resolv.conf
    cache 30
    loop
    reload
    loadbalance
}
```
In this scenario if a valid Ingress or Service in the cluster does not match `example.com`, the request will be forwarded to the host's resolvers. In my case this is helpful because I run a split-brain DNS setup and if a record isn't defined locally in the cluster, I want to attempt to resolve it from my external DNS server as well (and only then ultimately return `NXDOMAIN` if it doesn't exist).