### PR TITLE
Allow root zone queries and fall through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coredns
 tilt_modules
 .helm
 .vscode
+.idea

--- a/apex_test.go
+++ b/apex_test.go
@@ -19,6 +19,7 @@ func TestApex(t *testing.T) {
 	gw.Next = test.NextHandler(dns.RcodeSuccess, nil)
 	gw.Controller = ctrl
 	gw.ExternalAddrFunc = selfAddressTest
+	setupEmptyLookupFuncs()
 
 	ctx := context.TODO()
 	for i, tc := range testsApex {
@@ -48,7 +49,7 @@ var testsApex = []test.Case{
 	{
 		Qname: "example.com.", Qtype: dns.TypeSOA,
 		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
+		Ns: []dns.RR{
 			test.SOA("example.com.	60	IN	SOA	dns1.kube-system.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},

--- a/gateway.go
+++ b/gateway.go
@@ -118,10 +118,10 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return dns.RcodeServerFailure, plugin.Error(thisPlugin, fmt.Errorf("Could not sync required resources"))
 	}
 
-	var is_root_zone_query bool
+	var isRootZoneQuery bool
 	for _, z := range gw.Zones {
 		if state.Name() == z { // apex query
-			is_root_zone_query = true
+			isRootZoneQuery = true
 			break
 		}
 		if dns.IsSubDomain(gw.apex+"."+z, state.Name()) {
@@ -171,7 +171,7 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		m.Authoritative = true
 		m.Answer = []dns.RR{gw.soa(state)}
 	case dns.TypeNS:
-		if is_root_zone_query {
+		if isRootZoneQuery {
 			m.Answer = gw.nameservers(state)
 
 			addr := gw.ExternalAddrFunc(state)

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -3,10 +3,11 @@ package gateway
 import (
 	"context"
 	"errors"
-	"github.com/coredns/coredns/plugin/pkg/fall"
 	"net"
 	"strings"
 	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/fall"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
@@ -82,6 +83,7 @@ func TestGatewayFallthrough(t *testing.T) {
 	gw := newGateway()
 	gw.Zones = []string{"example.com."}
 	gw.Next = test.NextHandler(dns.RcodeSuccess, Fallen{})
+	gw.ExternalAddrFunc = selfAddressTest
 	gw.Controller = ctrl
 	setupTestLookupFuncs()
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -65,77 +65,77 @@ func TestGateway(t *testing.T) {
 }
 
 var tests = []test.Case{
-	// Existing Service
+	// Existing Service | Test 0
 	{
 		Qname: "svc1.ns1.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc1.ns1.example.com.	60	IN	A	192.0.1.1"),
 		},
 	},
-	// Existing Ingress
+	// Existing Ingress | Test 1
 	{
 		Qname: "domain.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("domain.example.com.	60	IN	A	192.0.0.1"),
 		},
 	},
-	// Ingress takes precedence over services
+	// Ingress takes precedence over services | Test 2
 	{
 		Qname: "svc2.ns1.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc2.ns1.example.com.	60	IN	A	192.0.0.2"),
 		},
 	},
-	// Non-existing Service
+	// Non-existing Service | Test 3
 	{
 		Qname: "svcX.ns1.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("example.com.	60	IN	SOA	dns1.kube-system.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
-	// Non-existing Ingress
+	// Non-existing Ingress | Test 4
 	{
 		Qname: "d0main.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("example.com.	60	IN	SOA	dns1.kube-system.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
-	// SOA for the existing domain
+	// SOA for the existing domain | Test 5
 	{
 		Qname: "domain.example.com.", Qtype: dns.TypeSOA, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("example.com.	60	IN	SOA	dns1.kube-system.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
-	// Service with no public addresses
+	// Service with no public addresses | Test 6
 	{
 		Qname: "svc3.ns1.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("example.com.	60	IN	SOA	dns1.kube-system.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
-	// Real service, wrong query type
+	// Real service, wrong query type | Test 7
 	{
-		Qname: "svc3.ns1.example.com.", Qtype: dns.TypeAAAA, Rcode: dns.RcodeNameError,
+		Qname: "svc3.ns1.example.com.", Qtype: dns.TypeCNAME, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("example.com.	60	IN	SOA	dns1.kube-system.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
-	// Ingress FQDN == zone
+	// Ingress FQDN == zone | Test 8
 	{
 		Qname: "example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
-		Ns: []dns.RR{
-			test.SOA("example.com.	60	IN	SOA	dns1.kube-system.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+		Answer: []dns.RR{
+			test.A("example.com.	60	IN	A	192.0.0.3"),
 		},
 	},
-	// Existing Ingress with a mix of lower and upper case letters
+	// Existing Ingress with a mix of lower and upper case letters | Test 9
 	{
 		Qname: "dOmAiN.eXamPLe.cOm.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("domain.example.com.	60	IN	A	192.0.0.1"),
 		},
 	},
-	// Existing Service with a mix of lower and upper case letters
+	// Existing Service with a mix of lower and upper case letters | Test 10
 	{
 		Qname: "svC1.Ns1.exAmplE.Com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{


### PR DESCRIPTION
This PR allows to query the zone root domain and fall through if it doesn't match a resource.

**Tests needs to be adjusted after agreement on actual behaviour.**

Fixes #35 