### PR TITLE
Fixed missing secondary value from Helm chart

### DIFF
--- a/charts/k8s-gateway/templates/configmap.yaml
+++ b/charts/k8s-gateway/templates/configmap.yaml
@@ -23,6 +23,9 @@ data:
         k8s_gateway "{{ required "Delegated domain ('domain') is mandatory " .Values.domain }}" {
           apex {{ .Values.apex | default (include "k8s-gateway.fqdn" .) }}
           ttl {{ .Values.ttl }}
+          {{- if .Values.secondary }}
+          secondary {{ .Values.secondary }}
+          {{- end }}
           {{- if .Values.watchedResources }}
           resources {{ join " " .Values.watchedResources }}
           {{- end }}

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -17,7 +17,7 @@ resources: {}
 watchedResources: []
 
 # Service name of a secondary DNS server (should be `serviceName.namespace`)
-secondaryDNS: ""
+secondary: ""
 
 # Override the default `serviceName.namespace` domain apex
 apex: ""


### PR DESCRIPTION
Helm values.yaml secondary key did not match up with the readme, and the configmap was missing an entry for a secondary nameserver. Both have been fixed.