### PR TITLE
Fix Helm Chart's priorityClass rendering

### DIFF
--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: 0.2.2
 maintainers:
   - email: mmkashin@gmail.com

--- a/charts/k8s-gateway/templates/deployment.yaml
+++ b/charts/k8s-gateway/templates/deployment.yaml
@@ -62,6 +62,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.priorityClassName -}}
+      {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}


### PR DESCRIPTION
Remove extra right strip, fixing a YAML parsing error.

Before:
```
$ helm template ./k8s-gateway --set domain=my.domain --set priorityClassName="testing"
Error: YAML parse error on k8s-gateway/templates/deployment.yaml: error converting YAML to JSON: yaml: line 62: mapping values are not allowed in this context
```

After:
```
$ helm template ./k8s-gateway --set domain=my.domain --set priorityClassName="testing"
<correctly rendered YAML with no error>
```

I included a bump to the Helm chart version as part of this change set.