### PR TITLE
feat: release binary for freebsd

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,10 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - freebsd
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: freebsd
+        goarch: arm64


### PR DESCRIPTION
Enable creating a freebsd binary on release (useful to deploy on opnsense or pfsense)