### PR TITLE
Added support for External-DNS Annotations for Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin relies on its own connection to the k8s API server and doesn't share
 | ---- | ---------------- | -------- |
 | HTTPRoute<sup>[1](#foot1)</sup> | all FQDNs from `spec.hostnames` matching configured zones | `gateway.status.addresses`<sup>[2](#foot2)</sup> |
 | Ingress | all FQDNs from `spec.rules[*].host` matching configured zones | `.status.loadBalancer.ingress` |
-| Service<sup>[3](#foot3)</sup> | `name.namespace` + any of the configured zones OR any string consisting of lower case alphanumeric characters, '-' or '.', specified in the `coredns.io/hostname` annotation (see [this](https://github.com/ori-edge/k8s_gateway/blob/master/test/service-annotation.yml#L8) for an example) | `.status.loadBalancer.ingress` |
+| Service<sup>[3](#foot3)</sup> | `name.namespace` + any of the configured zones OR any string consisting of lower case alphanumeric characters, '-' or '.', specified in the `coredns.io/hostname` or `external-dns.alpha.kubernetes.io/hostname` annotations (see [this](https://github.com/ori-edge/k8s_gateway/blob/master/test/service-annotation.yml#L8) for an example) | `.status.loadBalancer.ingress` |
 | VirtualServer<sup>[4](#foot4)</sup> | `spec.host` | `.status.externalEnpoints.ip` |
 
 


### PR DESCRIPTION
This adds support for the Annotation currently used by External-DNS, `external-dns.alpha.kubernetes.io/hostname`,  for Service types. Since a lot of software out there has adopted external-dns as it's default supported means of external DNS resolution. This simplifies those integrations. 

Of note the support for TTL annotations, `external-dns.alpha.kubernetes.io/ttl`, was not added as k8s_gateway doesn't have support for Controller resolved TTLs overriding the default. 