### PR TITLE
Build for mips64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - mips64
     ignore:
       - goos: freebsd
         goarch: arm64

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN := $(shell basename $$PWD)
 COMMIT := $(shell git describe --dirty --always)
 TAG := $(shell git describe --tags --dirty || echo latest)
 LDFLAGS := "-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(COMMIT)"
-ARCHS := "linux/amd64,linux/arm64"
+ARCHS := "linux/amd64,linux/arm64,linux/mips64"
 
 # Where to push the docker image.
 REGISTRY ?= quay.io/oriedge


### PR DESCRIPTION
Adding building for mips64 too which is used by EdgeRouter-4, EdgeRouter-12 for example from Ubiquiti.