### PR TITLE
fix chart indentation of extraZonePlugins

### DIFF
--- a/charts/k8s-gateway/templates/configmap.yaml
+++ b/charts/k8s-gateway/templates/configmap.yaml
@@ -31,8 +31,7 @@ data:
           {{- end }}
         }
         {{- range .Values.extraZonePlugins }}
-        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
-          {{ .configBlock | indent 2 }}
+        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} { {{ .configBlock | nindent 10 }}
         }{{ end }}
         {{- end }}
         {{- range .Values.zoneFiles }}


### PR DESCRIPTION
currently (tested in v0.3.3 and master) when an extraZonePlugins block is specified, `blockConfig` is indented using 2 spaces which breaks the yaml rendering of the configmap.

If I use this values file

```yaml
domain: test.lan
extraZonePlugins:
  - name: hosts
    configBlock: |
      192.168.1.20 host0
      192.168.1.21 host1
```

helm can't render the chart using `helm template -s templates/configmap.yaml -f VALUES k8s-gateway` and crashes with this error:

`Error: YAML parse error on k8s-gateway/templates/configmap.yaml: error converting YAML to JSON: yaml: line 23: could not find expected ':'`

Here is the output of the configmap when passing the flag `--debug`:

```yaml
data:
  Corefile: |-
    .:1053 {
        k8s_gateway test.lan {
          apex release-name-k8s-gateway.default
          ttl 300
        }
        hosts {
            192.168.1.20 host0
  192.168.1.21 host1
  
        }
    }
```

It is fixed by using `| nindent 10` when rendering `.blockConfig`:

```yaml
data:
  Corefile: |-
    .:1053 {
        k8s_gateway test.lan {
          apex release-name-k8s-gateway.default
          ttl 300
        }
        hosts { 
          192.168.1.20 host0
          192.168.1.21 host1
          
        }
    }
```

