### PR TITLE
feat(gateway-api): Add initial support for tls and grpc routes

### DIFF
--- a/Tiltfile.nerdctl
+++ b/Tiltfile.nerdctl
@@ -1,20 +1,20 @@
 allow_k8s_contexts('colima')
 allow_k8s_contexts('local')
 
-# using others with the makefile
-load('ext://restart_process', 'docker_build_with_restart')
+# using lima
+load('ext://nerdctl', 'nerdctl_build')
 load('ext://helm_remote', 'helm_remote')
 
 IMG = 'localhost:5000/coredns'
 
 def binary():
-    return "CGO_ENABLED=0  GOOS=linux GOARCH=amd64 GO111MODULE=on go build cmd/coredns.go"
+    return "CGO_ENABLED=0  GOOS=linux GOARCH=arm64 GO111MODULE=on go build cmd/coredns.go"
 
 local_resource('recompile', binary(), deps=['cmd', 'gateway.go', 'kubernetes.go', 'setup.go', 'apex.go'])
 
-
-docker_build_with_restart(IMG, '.',
-    dockerfile='tilt.Dockerfile',
+# if using mac m1+, you'll need to use colima
+nerdctl_build(IMG, '.',
+    dockerfile='tilt.Dockerfile', 
     entrypoint=['/coredns'], 
     live_update=[
         sync('./coredns', '/coredns'),
@@ -28,15 +28,14 @@ helm_remote('cilium',
             repo_name='cilium',
             values=['./test/cilium/helm-values.yaml'],
             repo_url='https://helm.cilium.io')
-k8s_yaml('./test/cilium/dual-stack/crd-values.yaml')
-
+k8s_yaml('./test/cilium/single-stack/crd-values.yaml')
 
 # CoreDNS with updated RBAC
 k8s_yaml(helm(
     './charts/k8s-gateway',
     namespace="kube-system",
     name='excoredns',
-    values=['./test/dual-stack/k8s-gateway-values.yaml'],
+    values=['./test/single-stack/k8s-gateway-values.yaml'],
     )
 )
 
@@ -80,5 +79,5 @@ k8s_kind('GRPCRoute', api_version='gateway.networking.k8s.io/v1alpha2')
 k8s_kind('Gateway', api_version='gateway.networking.k8s.io/v1beta1')
 k8s_yaml('./test/gateway-api/resources.yml')
 k8s_yaml('./test/gatewayclasses.yaml')
-k8s_yaml('./test/dual-stack/service-annotation.yml')
-k8s_yaml('./test/dual-stack/ingress-services.yml')
+k8s_yaml('./test/single-stack/service-annotation.yml')
+k8s_yaml('./test/single-stack/ingress-services.yml')

--- a/apex_dual_test.go
+++ b/apex_dual_test.go
@@ -13,8 +13,13 @@ import (
 )
 
 func setupEmptyLookupFuncs() {
-
 	if resource := lookupResource("HTTPRoute"); resource != nil {
+		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
+	}
+	if resource := lookupResource("TLSRoute"); resource != nil {
+		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
+	}
+	if resource := lookupResource("GRPCRoute"); resource != nil {
 		resource.lookup = func(_ []string) []netip.Addr { return []netip.Addr{} }
 	}
 	if resource := lookupResource("Ingress"); resource != nil {
@@ -26,7 +31,6 @@ func setupEmptyLookupFuncs() {
 }
 
 func TestDualNS(t *testing.T) {
-
 	ctrl := &KubeController{hasSynced: true}
 	gw := newGateway()
 	gw.Zones = []string{"example.com."}

--- a/examples/install-clusterwide.yml
+++ b/examples/install-clusterwide.yml
@@ -31,22 +31,29 @@ kind: ClusterRole
 metadata:
   name: excoredns
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - namespaces
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - "*"
+    verbs:
+      - watch
+      - list
 ---
 # Source: coredns/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -58,9 +65,9 @@ roleRef:
   kind: ClusterRole
   name: excoredns
 subjects:
-- kind: ServiceAccount
-  name: excoredns
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: excoredns
+    namespace: kube-system
 ---
 apiVersion: v1
 kind: Service
@@ -71,7 +78,7 @@ spec:
   selector:
     k8s-app: "excoredns"
   ports:
-  - {port: 53, protocol: UDP, name: udp-53}
+    - { port: 53, protocol: UDP, name: udp-53 }
   type: LoadBalancer
 ---
 apiVersion: apps/v1
@@ -92,27 +99,27 @@ spec:
       serviceAccountName: excoredns
       dnsPolicy: ClusterFirst
       containers:
-      - name: "coredns"
-        image: "quay.io/oriedge/k8s_gateway"
-        imagePullPolicy: IfNotPresent
-        args: [ "-conf", "/etc/coredns/Corefile" ]
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/coredns
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        ports:
-        - {containerPort: 53, protocol: UDP, name: udp-53}
-        - {containerPort: 53, protocol: TCP, name: tcp-53}
+        - name: "coredns"
+          image: "quay.io/oriedge/k8s_gateway"
+          imagePullPolicy: IfNotPresent
+          args: ["-conf", "/etc/coredns/Corefile"]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          ports:
+            - { containerPort: 53, protocol: UDP, name: udp-53 }
+            - { containerPort: 53, protocol: TCP, name: tcp-53 }
       volumes:
         - name: config-volume
           configMap:
             name: excoredns
             items:
-            - key: Corefile
-              path: Corefile
+              - key: Corefile
+                path: Corefile

--- a/gateway.go
+++ b/gateway.go
@@ -28,6 +28,14 @@ var orderedResources = []*resourceWithIndex{
 		lookup: noop,
 	},
 	{
+		name:   "TLSRoute",
+		lookup: noop,
+	},
+	{
+		name:   "GRPCRoute",
+		lookup: noop,
+	},
+	{
 		name:   "VirtualServer",
 		lookup: noop,
 	},

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -26,7 +26,7 @@ type Fallen struct {
 }
 
 func TestLookup(t *testing.T) {
-	real := []string{"Ingress", "Service", "HTTPRoute", "VirtualServer"}
+	real := []string{"Ingress", "Service", "HTTPRoute", "TLSRoute", "GRPCRoute", "VirtualServer"}
 	fake := []string{"Pod", "Gateway"}
 
 	for _, resource := range real {
@@ -97,10 +97,10 @@ func TestPluginFallthrough(t *testing.T) {
 		_, err := gw.ServeDNS(ctx, w, r)
 
 		if errors.As(err, &Fallen{}) && !tc.FallthroughExpected {
-			t.Fatalf("Test %d query resulted unexpectidly in a fall through instead of a response", i)
+			t.Fatalf("Test %d query resulted unexpectedly in a fall through instead of a response", i)
 		}
 		if err == nil && tc.FallthroughExpected {
-			t.Fatalf("Test %d query resulted unexpectidly in a response instead of a fall through", i)
+			t.Fatalf("Test %d query resulted unexpectedly in a response instead of a fall through", i)
 		}
 	}
 }
@@ -307,14 +307,14 @@ func testVirtualServerLookup(keys []string) (results []netip.Addr) {
 	return results
 }
 
-var testHTTPRouteIndexes = map[string][]netip.Addr{
+var testRouteIndexes = map[string][]netip.Addr{
 	"domain.gw.example.com": {netip.MustParseAddr("192.0.2.1")},
 	"shadow.example.com":    {netip.MustParseAddr("192.0.2.4")},
 }
 
-func testHTTPRouteLookup(keys []string) (results []netip.Addr) {
+func testRouteLookup(keys []string) (results []netip.Addr) {
 	for _, key := range keys {
-		results = append(results, testHTTPRouteIndexes[strings.ToLower(key)]...)
+		results = append(results, testRouteIndexes[strings.ToLower(key)]...)
 	}
 	return results
 }
@@ -330,6 +330,12 @@ func setupLookupFuncs() {
 		resource.lookup = testVirtualServerLookup
 	}
 	if resource := lookupResource("HTTPRoute"); resource != nil {
-		resource.lookup = testHTTPRouteLookup
+		resource.lookup = testRouteLookup
+	}
+	if resource := lookupResource("TLSRoute"); resource != nil {
+		resource.lookup = testRouteLookup
+	}
+	if resource := lookupResource("GRPCRoute"); resource != nil {
+		resource.lookup = testRouteLookup
 	}
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayClient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
@@ -33,6 +34,8 @@ const (
 	serviceHostnameIndex             = "serviceHostname"
 	gatewayUniqueIndex               = "gatewayIndex"
 	httpRouteHostnameIndex           = "httpRouteHostname"
+	tlsRouteHostnameIndex            = "tlsRouteHostname"
+	grpcRouteHostnameIndex           = "grpcRouteHostname"
 	virtualServerHostnameIndex       = "virtualServerHostname"
 	hostnameAnnotationKey            = "coredns.io/hostname"
 	externalDnsHostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
@@ -48,7 +51,6 @@ type KubeController struct {
 }
 
 func newKubeController(ctx context.Context, c *kubernetes.Clientset, gw *gatewayClient.Clientset, nc *k8s_nginx.Clientset) *KubeController {
-
 	log.Infof("Building k8s_gateway controller")
 
 	ctrl := &KubeController{
@@ -58,18 +60,18 @@ func newKubeController(ctx context.Context, c *kubernetes.Clientset, gw *gateway
 	}
 
 	if existGatewayCRDs(ctx, gw) {
-		if resource := lookupResource("HTTPRoute"); resource != nil {
-			gatewayController := cache.NewSharedIndexInformer(
-				&cache.ListWatch{
-					ListFunc:  gatewayLister(ctx, ctrl.gwClient, core.NamespaceAll),
-					WatchFunc: gatewayWatcher(ctx, ctrl.gwClient, core.NamespaceAll),
-				},
-				&gatewayapi_v1beta1.Gateway{},
-				defaultResyncPeriod,
-				cache.Indexers{gatewayUniqueIndex: gatewayIndexFunc},
-			)
-			ctrl.controllers = append(ctrl.controllers, gatewayController)
+		gatewayController := cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc:  gatewayLister(ctx, ctrl.gwClient, core.NamespaceAll),
+				WatchFunc: gatewayWatcher(ctx, ctrl.gwClient, core.NamespaceAll),
+			},
+			&gatewayapi_v1beta1.Gateway{},
+			defaultResyncPeriod,
+			cache.Indexers{gatewayUniqueIndex: gatewayIndexFunc},
+		)
+		ctrl.controllers = append(ctrl.controllers, gatewayController)
 
+		if resource := lookupResource("HTTPRoute"); resource != nil {
 			httpRouteController := cache.NewSharedIndexInformer(
 				&cache.ListWatch{
 					ListFunc:  httpRouteLister(ctx, ctrl.gwClient, core.NamespaceAll),
@@ -81,6 +83,34 @@ func newKubeController(ctx context.Context, c *kubernetes.Clientset, gw *gateway
 			)
 			resource.lookup = lookupHttpRouteIndex(httpRouteController, gatewayController)
 			ctrl.controllers = append(ctrl.controllers, httpRouteController)
+		}
+
+		if resource := lookupResource("TLSRoute"); resource != nil {
+			tlsRouteController := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc:  tlsRouteLister(ctx, ctrl.gwClient, core.NamespaceAll),
+					WatchFunc: tlsRouteWatcher(ctx, ctrl.gwClient, core.NamespaceAll),
+				},
+				&gatewayapi_v1alpha2.TLSRoute{},
+				defaultResyncPeriod,
+				cache.Indexers{tlsRouteHostnameIndex: tlsRouteHostnameIndexFunc},
+			)
+			resource.lookup = lookupTLSRouteIndex(tlsRouteController, gatewayController)
+			ctrl.controllers = append(ctrl.controllers, tlsRouteController)
+		}
+
+		if resource := lookupResource("GRPCRoute"); resource != nil {
+			grpcRouteController := cache.NewSharedIndexInformer(
+				&cache.ListWatch{
+					ListFunc:  grpcRouteLister(ctx, ctrl.gwClient, core.NamespaceAll),
+					WatchFunc: grpcRouteWatcher(ctx, ctrl.gwClient, core.NamespaceAll),
+				},
+				&gatewayapi_v1alpha2.GRPCRoute{},
+				defaultResyncPeriod,
+				cache.Indexers{grpcRouteHostnameIndex: grpcRouteHostnameIndexFunc},
+			)
+			resource.lookup = lookupGRPCRouteIndex(grpcRouteController, gatewayController)
+			ctrl.controllers = append(ctrl.controllers, grpcRouteController)
 		}
 	}
 
@@ -188,7 +218,6 @@ func (gw *Gateway) RunKubeController(ctx context.Context) error {
 }
 
 func existGatewayCRDs(ctx context.Context, c *gatewayClient.Clientset) bool {
-
 	_, err := c.GatewayV1beta1().Gateways("").List(ctx, metav1.ListOptions{})
 	return handleCRDCheckError(err, "GatewayAPI", "gateway.networking.k8s.io")
 }
@@ -235,6 +264,18 @@ func httpRouteLister(ctx context.Context, c gatewayClient.Interface, ns string) 
 	}
 }
 
+func tlsRouteLister(ctx context.Context, c gatewayClient.Interface, ns string) func(metav1.ListOptions) (runtime.Object, error) {
+	return func(opts metav1.ListOptions) (runtime.Object, error) {
+		return c.GatewayV1alpha2().TLSRoutes(ns).List(ctx, opts)
+	}
+}
+
+func grpcRouteLister(ctx context.Context, c gatewayClient.Interface, ns string) func(metav1.ListOptions) (runtime.Object, error) {
+	return func(opts metav1.ListOptions) (runtime.Object, error) {
+		return c.GatewayV1alpha2().GRPCRoutes(ns).List(ctx, opts)
+	}
+}
+
 func gatewayLister(ctx context.Context, c gatewayClient.Interface, ns string) func(metav1.ListOptions) (runtime.Object, error) {
 	return func(opts metav1.ListOptions) (runtime.Object, error) {
 		return c.GatewayV1beta1().Gateways(ns).List(ctx, opts)
@@ -262,6 +303,18 @@ func virtualServerLister(ctx context.Context, c k8s_nginx.Interface, ns string) 
 func httpRouteWatcher(ctx context.Context, c gatewayClient.Interface, ns string) func(metav1.ListOptions) (watch.Interface, error) {
 	return func(opts metav1.ListOptions) (watch.Interface, error) {
 		return c.GatewayV1beta1().HTTPRoutes(ns).Watch(ctx, opts)
+	}
+}
+
+func tlsRouteWatcher(ctx context.Context, c gatewayClient.Interface, ns string) func(metav1.ListOptions) (watch.Interface, error) {
+	return func(opts metav1.ListOptions) (watch.Interface, error) {
+		return c.GatewayV1alpha2().TLSRoutes(ns).Watch(ctx, opts)
+	}
+}
+
+func grpcRouteWatcher(ctx context.Context, c gatewayClient.Interface, ns string) func(metav1.ListOptions) (watch.Interface, error) {
+	return func(opts metav1.ListOptions) (watch.Interface, error) {
+		return c.GatewayV1alpha2().GRPCRoutes(ns).Watch(ctx, opts)
 	}
 }
 
@@ -307,6 +360,34 @@ func httpRouteHostnameIndexFunc(obj interface{}) ([]string, error) {
 	var hostnames []string
 	for _, hostname := range httpRoute.Spec.Hostnames {
 		log.Debugf("Adding index %s for httpRoute %s", httpRoute.Name, hostname)
+		hostnames = append(hostnames, string(hostname))
+	}
+	return hostnames, nil
+}
+
+func tlsRouteHostnameIndexFunc(obj interface{}) ([]string, error) {
+	tlsRoute, ok := obj.(*gatewayapi_v1alpha2.TLSRoute)
+	if !ok {
+		return []string{}, nil
+	}
+
+	var hostnames []string
+	for _, hostname := range tlsRoute.Spec.Hostnames {
+		log.Debugf("Adding index %s for tlsRoute %s", tlsRoute.Name, hostname)
+		hostnames = append(hostnames, string(hostname))
+	}
+	return hostnames, nil
+}
+
+func grpcRouteHostnameIndexFunc(obj interface{}) ([]string, error) {
+	grpcRoute, ok := obj.(*gatewayapi_v1alpha2.GRPCRoute)
+	if !ok {
+		return []string{}, nil
+	}
+
+	var hostnames []string
+	for _, hostname := range grpcRoute.Spec.Hostnames {
+		log.Debugf("Adding index %s for grpcRoute %s", grpcRoute.Name, hostname)
 		hostnames = append(hostnames, string(hostname))
 	}
 	return hostnames, nil
@@ -442,8 +523,41 @@ func lookupHttpRouteIndex(http, gw cache.SharedIndexInformer) func([]string) []n
 	}
 }
 
-func lookupGateways(gw cache.SharedIndexInformer, refs []gatewayapi_v1beta1.ParentReference, ns string) (result []netip.Addr) {
+func lookupTLSRouteIndex(tls, gw cache.SharedIndexInformer) func([]string) []netip.Addr {
+	return func(indexKeys []string) (result []netip.Addr) {
+		var objs []interface{}
+		for _, key := range indexKeys {
+			obj, _ := tls.GetIndexer().ByIndex(tlsRouteHostnameIndex, strings.ToLower(key))
+			objs = append(objs, obj...)
+		}
+		log.Debugf("Found %d matching tlsRoute objects", len(objs))
 
+		for _, obj := range objs {
+			tlsRoute, _ := obj.(*gatewayapi_v1alpha2.TLSRoute)
+			result = append(result, lookupGateways(gw, tlsRoute.Spec.ParentRefs, tlsRoute.Namespace)...)
+		}
+		return
+	}
+}
+
+func lookupGRPCRouteIndex(grpc, gw cache.SharedIndexInformer) func([]string) []netip.Addr {
+	return func(indexKeys []string) (result []netip.Addr) {
+		var objs []interface{}
+		for _, key := range indexKeys {
+			obj, _ := grpc.GetIndexer().ByIndex(grpcRouteHostnameIndex, strings.ToLower(key))
+			objs = append(objs, obj...)
+		}
+		log.Debugf("Found %d matching grpcRoute objects", len(objs))
+
+		for _, obj := range objs {
+			grpcRoute, _ := obj.(*gatewayapi_v1alpha2.GRPCRoute)
+			result = append(result, lookupGateways(gw, grpcRoute.Spec.ParentRefs, grpcRoute.Namespace)...)
+		}
+		return
+	}
+}
+
+func lookupGateways(gw cache.SharedIndexInformer, refs []gatewayapi_v1beta1.ParentReference, ns string) (result []netip.Addr) {
 	for _, gwRef := range refs {
 
 		if gwRef.Namespace != nil {
@@ -481,7 +595,6 @@ func lookupIngressIndex(ctrl cache.SharedIndexInformer) func([]string) []netip.A
 }
 
 func fetchGatewayIPs(gw *gatewayapi_v1beta1.Gateway) (results []netip.Addr) {
-
 	for _, addr := range gw.Status.Addresses {
 		if *addr.Type == gatewayapi_v1beta1.IPAddressType {
 			addr, err := netip.ParseAddr(addr.Value)
@@ -510,7 +623,6 @@ func fetchGatewayIPs(gw *gatewayapi_v1beta1.Gateway) (results []netip.Addr) {
 }
 
 func fetchServiceLoadBalancerIPs(ingresses []core.LoadBalancerIngress) (results []netip.Addr) {
-
 	for _, address := range ingresses {
 		if address.Hostname != "" {
 			log.Debugf("Looking up hostname %s", address.Hostname)
@@ -537,7 +649,6 @@ func fetchServiceLoadBalancerIPs(ingresses []core.LoadBalancerIngress) (results 
 }
 
 func fetchIngressLoadBalancerIPs(ingresses []networking.IngressLoadBalancerIngress) (results []netip.Addr) {
-
 	for _, address := range ingresses {
 		if address.Hostname != "" {
 			log.Debugf("Looking up hostname %s", address.Hostname)

--- a/test/backend.yml
+++ b/test/backend.yml
@@ -17,10 +17,9 @@ spec:
         app: backend
     spec:
       containers:
-      - image: nginx
-        imagePullPolicy: Always
-        name: nginx
-
+        - image: nginx
+          imagePullPolicy: Always
+          name: nginx
 ---
 apiVersion: v1
 kind: Service
@@ -29,9 +28,9 @@ metadata:
   namespace: default
 spec:
   ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 80
+    - port: 80
+      protocol: TCP
+      targetPort: 80
   selector:
     app: backend
   sessionAffinity: None

--- a/test/cilium/dual-stack/crd-values.yaml
+++ b/test/cilium/dual-stack/crd-values.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: default
+spec:
+  cidrs:
+    - cidr: 198.51.100.0/24
+    - cidr: fd12:3456:789a:1::/64
+
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: default
+spec:
+  loadBalancerIPs: true
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux

--- a/test/cilium/helm-values.yaml
+++ b/test/cilium/helm-values.yaml
@@ -1,0 +1,58 @@
+bpf:
+  masquerade: true
+cluster:
+  name: local
+containerRuntime:
+  integration: containerd
+endpointRoutes:
+  enabled: true
+enableCiliumEndpointSlice: true
+ingressController:
+  enabled: true
+  loadBalancerMode: shared
+gatewayAPI:
+  enabled: true
+l7Proxy: true
+l2announcements:
+  enabled: true
+ipv4NativeRoutingCIDR: 10.42.0.0/16
+ipam:
+  mode: "cluster-pool"
+  operator:
+    clusterPoolIPv4PodCIDRList:
+      - "10.43.0.0/16"
+    clusterPoolIPv4MaskSize: 24
+    # clusterPoolIPv6PodCIDRList:
+    #   - "fd00::/104"
+    # clusterPoolIPv6MaskSize: 120
+kubeProxyReplacement: true
+kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
+k8sServiceHost: 127.0.0.1
+k8sServicePort: 6443
+localRedirectPolicy: true
+operator:
+  replicas: 1
+  rollOutPods: true
+rollOutCiliumPods: true
+securityContext:
+  privileged: true
+  capabilities:
+    ciliumAgent:
+      - PERFMON
+      - BPF
+      - CHOWN
+      - KILL
+      - NET_ADMIN
+      - NET_RAW
+      - IPC_LOCK
+      - SYS_ADMIN
+      - SYS_RESOURCE
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUI
+    cleanCiliumState:
+      - NET_ADMIN
+      - SYS_ADMIN
+      - SYS_RESOURCE
+tunnel: disabled

--- a/test/cilium/single-stack/crd-values.yaml
+++ b/test/cilium/single-stack/crd-values.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: default
+spec:
+  cidrs:
+    - cidr: 198.51.100.0/24
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: default
+spec:
+  loadBalancerIPs: true
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux

--- a/test/dual-stack/ingress-services.yml
+++ b/test/dual-stack/ingress-services.yml
@@ -7,16 +7,16 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: myservicea.foo.org
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: backend
-            port: 
-              number: 80
+    - host: myservicea.foo.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 80
 ---
 apiVersion: v1
 kind: Service
@@ -26,10 +26,10 @@ metadata:
 spec:
   ipFamilyPolicy: RequireDualStack
   ports:
-  - name: 80-80
-    port: 80
-    protocol: TCP
-    targetPort: 80
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
   selector:
     app: backend
   sessionAffinity: None

--- a/test/dual-stack/k8s-gateway-values.yaml
+++ b/test/dual-stack/k8s-gateway-values.yaml
@@ -1,0 +1,24 @@
+nameOverride: k8s-gateway
+image:
+  registry: localhost:5000
+  repository: coredns
+  tag: latest
+
+# Delegated domain
+domain: "foo.org"
+
+service:
+  type: NodePort
+  port: 53
+  annotations: {}
+  nodePort: 32553
+  # loadBalancerIP: 192.168.1.2
+  # externalTrafficPolicy: Local
+  # externalIPs:
+  #  - 192.168.1.3
+  ipFamilyPolicy: RequireDualStack
+
+debug:
+  enabled: true
+
+secure: false

--- a/test/dual-stack/service-annotation.yml
+++ b/test/dual-stack/service-annotation.yml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: annotation-good
+  namespace: default
+  annotations:
+    "coredns.io/hostname": "good.ok"
+spec:
+  ipFamilyPolicy: RequireDualStack
+  ports:
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: backend
+  sessionAffinity: None
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: annotation-bad
+  namespace: default
+  annotations:
+    "coredns.io/hostname": "abcd0123456789012345678901234567890123456789012345678901234567890"
+spec:
+  ipFamilyPolicy: RequireDualStack
+  ports:
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: backend
+  sessionAffinity: None
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: annotation-bad-2
+  namespace: default
+  annotations:
+    "coredns.io/hostname": "foo_bar"
+spec:
+  ipFamilyPolicy: RequireDualStack
+  ports:
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: backend
+  sessionAffinity: None
+  type: LoadBalancer

--- a/test/gateway-api/crds.yml
+++ b/test/gateway-api/crds.yml
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 #
-# Gateway API Standard channel install
+# Gateway API Experimental channel install
 #
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+# config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -25,7 +25,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
     gateway.networking.k8s.io/bundle-version: v0.8.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
@@ -462,7 +462,7 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+# config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -470,7 +470,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
     gateway.networking.k8s.io/bundle-version: v0.8.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:
@@ -2053,7 +2053,7 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+# config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2061,7 +2061,1712 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
     gateway.networking.k8s.io/bundle-version: v0.8.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: grpcroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GRPCRoute
+    listKind: GRPCRouteList
+    plural: grpcroutes
+    singular: grpcroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: "GRPCRoute provides a way to route gRPC requests. This includes
+          the capability to match requests by hostname, gRPC service, gRPC method,
+          or HTTP/2 header. Filters can be used to specify additional processing steps.
+          Backends specify where matching requests will be routed. \n GRPCRoute falls
+          under extended support within the Gateway API. Within the following specification,
+          the word \"MUST\" indicates that an implementation supporting GRPCRoute
+          must conform to the indicated requirement, but an implementation not supporting
+          this route type need not follow the requirement unless explicitly indicated.
+          \n Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType`
+          MUST accept HTTP/2 connections without an initial upgrade from HTTP/1.1,
+          i.e. via ALPN. If the implementation does not support this, then it MUST
+          set the \"Accepted\" condition to \"False\" for the affected listener with
+          a reason of \"UnsupportedProtocol\".  Implementations MAY also accept HTTP/2
+          connections with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute`
+          with the `HTTP` `ProtocolType` MUST support HTTP/2 over cleartext TCP (h2c,
+          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial upgrade
+          from HTTP/1.1, i.e. with prior knowledge (https://www.rfc-editor.org/rfc/rfc7540#section-3.4).
+          If the implementation does not support this, then it MUST set the \"Accepted\"
+          condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".
+          Implementations MAY also accept HTTP/2 connections with an upgrade from
+          HTTP/1, i.e. without prior knowledge."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GRPCRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostnames to match against
+                  the GRPC Host header to select a GRPCRoute to process the request.
+                  This matches the RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
+                  with a wildcard label (`*.`). The wildcard label MUST appear by
+                  itself as the first label. \n If a hostname is specified by both
+                  the Listener and GRPCRoute, there MUST be at least one intersecting
+                  hostname for the GRPCRoute to be attached to the Listener. For example:
+                  \n * A Listener with `test.example.com` as the hostname matches
+                  GRPCRoutes that have either not specified any hostnames, or have
+                  specified at least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes
+                  that have either not specified any hostnames or have specified at
+                  least one hostname that matches the Listener hostname. For example,
+                  `test.example.com` and `*.example.com` would both match. On the
+                  other hand, `example.com` and `test.example.net` would not match.
+                  \n Hostnames that are prefixed with a wildcard label (`*.`) are
+                  interpreted as a suffix match. That means that a match for `*.example.com`
+                  would match both `test.example.com`, and `foo.test.example.com`,
+                  but not `example.com`. \n If both the Listener and GRPCRoute have
+                  specified hostnames, any GRPCRoute hostnames that do not match the
+                  Listener hostname MUST be ignored. For example, if a Listener specified
+                  `*.example.com`, and the GRPCRoute specified `test.example.com`
+                  and `test.example.net`, `test.example.net` MUST NOT be considered
+                  for a match. \n If both the Listener and GRPCRoute have specified
+                  hostnames, and none match with the criteria above, then the GRPCRoute
+                  MUST NOT be accepted by the implementation. The implementation MUST
+                  raise an 'Accepted' Condition with a status of `False` in the corresponding
+                  RouteParentStatus. \n If a Route (A) of type HTTPRoute or GRPCRoute
+                  is attached to a Listener and that listener already has another
+                  Route (B) of the other type attached and the intersection of the
+                  hostnames of A and B is non-empty, then the implementation MUST
+                  accept exactly one of these two routes, determined by the following
+                  criteria, in order: \n * The oldest Route based on creation timestamp.
+                  * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
+                  \n The rejected Route MUST raise an 'Accepted' condition with a
+                  status of 'False' in the corresponding RouteParentStatus. \n Support:
+                  Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                    host. This matches the RFC 1123 definition of a hostname with
+                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard label
+                    must appear by itself as the first label. \n Hostname can be \"precise\"
+                    which is a domain name without the terminating dot of a network
+                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                    name prefixed with a single wildcard label (e.g. `*.example.com`).
+                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                    of lower case alphanumeric characters or '-', and must start and
+                    end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only) \n This
+                  API may be extended in the future to support additional kinds of
+                  parent resources. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. \n ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route. \n "
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile, experimental, ClusterIP Services only)
+                    \n This API may be extended in the future to support additional
+                    kinds of parent resources. \n The API object must be valid in
+                    the cluster; the Group and Kind must be registered in the cluster
+                    for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile, experimental, ClusterIP Services only) \n Support
+                        for other resources is Implementation-Specific."
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        \n ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n "
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. * Service: Port Name. When both Port (experimental)
+                        and SectionName are specified, the name and port of the selected
+                        listener must match both specified values. Note that attaching
+                        Routes to Services as Parents is part of experimental Mesh
+                        support and is not supported for any other purpose. \n Implementations
+                        MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName
+                        is interpreted. \n When unspecified (empty string), this will
+                        reference the entire resource. For the purpose of status,
+                        an attachment is considered successful if at least one section
+                        in the parent resource accepts it. For example, Gateway listeners
+                        can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from the referencing Route, the Route MUST be considered
+                        successfully attached. If no Gateway listeners accept attachment
+                        from this Route, the Route MUST be considered detached from
+                        the Gateway. \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && ( ( (!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''') ) || ( has(p1.__namespace__) && has(p2.__namespace__)
+                    && p1.__namespace__ == p2.__namespace__ ) ) ? ( ( ( (!has(p1.sectionName)
+                    || p1.sectionName == '''') && (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0) ) || ( ( (has(p1.sectionName) && p1.sectionName
+                    != '''') || (has(p1.port) && p1.port != 0) ) && ( (has(p2.sectionName)
+                    && p2.sectionName != '''') || (has(p2.port) && p2.port != 0) )
+                    ) ) ): true ))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of GRPC matchers, filters and actions.
+                items:
+                  description: GRPCRouteRule defines the semantics for matching a
+                    gRPC request based on conditions (matches), processing it (filters),
+                    and forwarding the request to an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST receive an `UNAVAILABLE` status.
+                        \n See the GRPCBackendRef definition for the rules about what
+                        makes a single GRPCBackendRef invalid. \n When a GRPCBackendRef
+                        is invalid, `UNAVAILABLE` statuses MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive an `UNAVAILABLE`
+                        status. \n For example, if two backends are specified with
+                        equal weights, and one is invalid, 50 percent of traffic MUST
+                        receive an `UNAVAILABLE` status. Implementations may choose
+                        how that 50 percent is determined. \n Support: Core for Kubernetes
+                        Service \n Support: Implementation-specific for any other
+                        resource \n Support for weight: Core"
+                      items:
+                        description: GRPCBackendRef defines how a GRPCRoute forwards
+                          a gRPC request.
+                        properties:
+                          filters:
+                            description: "Filters defined at this level MUST be executed
+                              if and only if the request is being forwarded to the
+                              backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in GRPCRouteRule.)"
+                            items:
+                              description: GRPCRouteFilter defines processing steps
+                                that must be completed during the request or response
+                                lifecycle. GRPCRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway
+                                implementations. Some examples include request or
+                                response modification, implementing authentication
+                                strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type
+                                of the filter.
+                              properties:
+                                extensionRef:
+                                  description: "ExtensionRef is an optional, implementation-specific
+                                    extension to the \"filter\" behavior.  For example,
+                                    resource \"myroutefilter\" in group \"networking.example.net\").
+                                    ExtensionRef MUST NOT be used for core and extended
+                                    filters. \n Support: Implementation-specific \n
+                                    This filter can be used multiple times within
+                                    the same rule."
+                                  properties:
+                                    group:
+                                      description: Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API
+                                        group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: "RequestHeaderModifier defines a schema
+                                    for a filter that modifies request headers. \n
+                                    Support: Core"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input: GET /foo HTTP/1.1
+                                        my-header: foo \n Config: add: - name: \"my-header\"
+                                        value: \"bar,baz\" \n Output: GET /foo HTTP/1.1
+                                        my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input: GET /foo HTTP/1.1 my-header1: foo
+                                        my-header2: bar my-header3: baz \n Config:
+                                        remove: [\"my-header1\", \"my-header3\"] \n
+                                        Output: GET /foo HTTP/1.1 my-header2: bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input: GET /foo HTTP/1.1 my-header:
+                                        foo \n Config: set: - name: \"my-header\"
+                                        value: \"bar\" \n Output: GET /foo HTTP/1.1
+                                        my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: "RequestMirror defines a schema for
+                                    a filter that mirrors requests. Requests are sent
+                                    to the specified destination, but responses from
+                                    that destination are ignored. \n This filter can
+                                    be used multiple times within the same rule. Note
+                                    that not all implementations will be able to support
+                                    mirroring to multiple backends. \n Support: Extended"
+                                  properties:
+                                    backendRef:
+                                      description: "BackendRef references a resource
+                                        where mirrored requests are sent. \n Mirrored
+                                        requests must be sent only to a single destination
+                                        endpoint within this BackendRef, irrespective
+                                        of how many endpoints are present within this
+                                        BackendRef. \n If the referent cannot be found,
+                                        this BackendRef is invalid and must be dropped
+                                        from the Gateway. The controller must ensure
+                                        the \"ResolvedRefs\" condition on the Route
+                                        status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+                                        \n If there is a cross-namespace reference
+                                        to an *existing* object that is not allowed
+                                        by a ReferenceGrant, the controller must ensure
+                                        the \"ResolvedRefs\"  condition on the Route
+                                        is set to `status: False`, with the \"RefNotPermitted\"
+                                        reason and not configure this backend in the
+                                        underlying implementation. \n In either error
+                                        case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about
+                                        the problem. \n Support: Extended for Kubernetes
+                                        Service \n Support: Implementation-specific
+                                        for any other resource"
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: Group is the group of the referent.
+                                            For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core
+                                            API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: "Kind is the Kubernetes resource
+                                            kind of the referent. For example \"Service\".
+                                            \n Defaults to \"Service\" when not specified.
+                                            \n ExternalName services can refer to
+                                            CNAME DNS records that may live outside
+                                            of the cluster and as such are difficult
+                                            to reason about in terms of conformance.
+                                            They also may not be safe to forward to
+                                            (see CVE-2021-25740 for more information).
+                                            Implementations SHOULD NOT support ExternalName
+                                            Services. \n Support: Core (Services with
+                                            a type other than ExternalName) \n Support:
+                                            Implementation-specific (Services with
+                                            type ExternalName)"
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: "Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local namespace is inferred. \n Note that
+                                            when a namespace different than the local
+                                            namespace is specified, a ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. \n Support:
+                                            Core"
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: Port specifies the destination
+                                            port number to use for this resource.
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
+                                            destination port might be derived from
+                                            the referent resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                  required:
+                                  - backendRef
+                                  type: object
+                                responseHeaderModifier:
+                                  description: "ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response headers. \n
+                                    Support: Extended"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input: GET /foo HTTP/1.1
+                                        my-header: foo \n Config: add: - name: \"my-header\"
+                                        value: \"bar,baz\" \n Output: GET /foo HTTP/1.1
+                                        my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input: GET /foo HTTP/1.1 my-header1: foo
+                                        my-header2: bar my-header3: baz \n Config:
+                                        remove: [\"my-header1\", \"my-header3\"] \n
+                                        Output: GET /foo HTTP/1.1 my-header2: bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input: GET /foo HTTP/1.1 my-header:
+                                        foo \n Config: set: - name: \"my-header\"
+                                        value: \"bar\" \n Output: GET /foo HTTP/1.1
+                                        my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter
+                                    to apply. As with other API fields, types are
+                                    classified into three conformance levels: \n -
+                                    Core: Filter types and their corresponding configuration
+                                    defined by \"Support: Core\" in this package,
+                                    e.g. \"RequestHeaderModifier\". All implementations
+                                    supporting GRPCRoute MUST support core filters.
+                                    \n - Extended: Filter types and their corresponding
+                                    configuration defined by \"Support: Extended\"
+                                    in this package, e.g. \"RequestMirror\". Implementers
+                                    are encouraged to support extended filters. \n
+                                    - Implementation-specific: Filters that are defined
+                                    and supported by specific vendors. In the future,
+                                    filters showing convergence in behavior across
+                                    multiple implementations will be considered for
+                                    inclusion in extended or core conformance levels.
+                                    Filter-specific configuration for such filters
+                                    is specified using the ExtensionRef field. `Type`
+                                    MUST be set to \"ExtensionRef\" for custom filters.
+                                    \n Implementers are encouraged to define custom
+                                    implementation types to extend the core API with
+                                    implementation-specific behavior. \n If a reference
+                                    to a custom filter type cannot be resolved, the
+                                    filter MUST NOT be skipped. Instead, requests
+                                    that would have been processed by that filter
+                                    MUST receive a HTTP error response. \n "
+                                  enum:
+                                  - ResponseHeaderModifier
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: "Kind is the Kubernetes resource kind of
+                              the referent. For example \"Service\". \n Defaults to
+                              \"Service\" when not specified. \n ExternalName services
+                              can refer to CNAME DNS records that may live outside
+                              of the cluster and as such are difficult to reason about
+                              in terms of conformance. They also may not be safe to
+                              forward to (see CVE-2021-25740 for more information).
+                              Implementations SHOULD NOT support ExternalName Services.
+                              \n Support: Core (Services with a type other than ExternalName)
+                              \n Support: Implementation-specific (Services with type
+                              ExternalName)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace different than the local
+                              namespace is specified, a ReferenceGrant object is required
+                              in the referent namespace to allow that namespace's
+                              owner to accept the reference. See the ReferenceGrant
+                              documentation for details. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: "Filters define the filters that are applied to
+                        requests that match this rule. \n The effects of ordering
+                        of multiple behaviors are currently unspecified. This can
+                        change in the future based on feedback during the alpha stage.
+                        \n Conformance-levels at this level are defined based on the
+                        type of filter: \n - ALL core filters MUST be supported by
+                        all implementations that support GRPCRoute. - Implementers
+                        are encouraged to support extended filters. - Implementation-specific
+                        custom filters have no API guarantees across implementations.
+                        \n Specifying the same filter multiple times is not supported
+                        unless explicitly indicated in the filter. \n If an implementation
+                        can not support a combination of filters, it must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to
+                        be set to status `False`, implementations may use the `IncompatibleFilters`
+                        reason to specify this configuration error. \n Support: Core"
+                      items:
+                        description: GRPCRouteFilter defines processing steps that
+                          must be completed during the request or response lifecycle.
+                          GRPCRouteFilters are meant as an extension point to express
+                          processing that may be done in Gateway implementations.
+                          Some examples include request or response modification,
+                          implementing authentication strategies, rate-limiting, and
+                          traffic shaping. API guarantee/conformance is defined based
+                          on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"filter\" behavior.  For example,
+                              resource \"myroutefilter\" in group \"networking.example.net\").
+                              ExtensionRef MUST NOT be used for core and extended
+                              filters. \n Support: Implementation-specific \n This
+                              filter can be used multiple times within the same rule."
+                            properties:
+                              group:
+                                description: Group is the group of the referent. For
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: "RequestHeaderModifier defines a schema for
+                              a filter that modifies request headers. \n Support:
+                              Core"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input: GET /foo HTTP/1.1 my-header: foo
+                                  \n Config: add: - name: \"my-header\" value: \"bar,baz\"
+                                  \n Output: GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
+                                  bar my-header3: baz \n Config: remove: [\"my-header1\",
+                                  \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
+                                  bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input: GET /foo HTTP/1.1 my-header: foo \n Config:
+                                  set: - name: \"my-header\" value: \"bar\" \n Output:
+                                  GET /foo HTTP/1.1 my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: "RequestMirror defines a schema for a filter
+                              that mirrors requests. Requests are sent to the specified
+                              destination, but responses from that destination are
+                              ignored. \n This filter can be used multiple times within
+                              the same rule. Note that not all implementations will
+                              be able to support mirroring to multiple backends. \n
+                              Support: Extended"
+                            properties:
+                              backendRef:
+                                description: "BackendRef references a resource where
+                                  mirrored requests are sent. \n Mirrored requests
+                                  must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many
+                                  endpoints are present within this BackendRef. \n
+                                  If the referent cannot be found, this BackendRef
+                                  is invalid and must be dropped from the Gateway.
+                                  The controller must ensure the \"ResolvedRefs\"
+                                  condition on the Route status is set to `status:
+                                  False` and not configure this backend in the underlying
+                                  implementation. \n If there is a cross-namespace
+                                  reference to an *existing* object that is not allowed
+                                  by a ReferenceGrant, the controller must ensure
+                                  the \"ResolvedRefs\"  condition on the Route is
+                                  set to `status: False`, with the \"RefNotPermitted\"
+                                  reason and not configure this backend in the underlying
+                                  implementation. \n In either error case, the Message
+                                  of the `ResolvedRefs` Condition should be used to
+                                  provide more detail about the problem. \n Support:
+                                  Extended for Kubernetes Service \n Support: Implementation-specific
+                                  for any other resource"
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group is the group of the referent.
+                                      For example, "gateway.networking.k8s.io". When
+                                      unspecified or empty string, core API group
+                                      is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: "Kind is the Kubernetes resource
+                                      kind of the referent. For example \"Service\".
+                                      \n Defaults to \"Service\" when not specified.
+                                      \n ExternalName services can refer to CNAME
+                                      DNS records that may live outside of the cluster
+                                      and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe
+                                      to forward to (see CVE-2021-25740 for more information).
+                                      Implementations SHOULD NOT support ExternalName
+                                      Services. \n Support: Core (Services with a
+                                      type other than ExternalName) \n Support: Implementation-specific
+                                      (Services with type ExternalName)"
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: "Namespace is the namespace of the
+                                      backend. When unspecified, the local namespace
+                                      is inferred. \n Note that when a namespace different
+                                      than the local namespace is specified, a ReferenceGrant
+                                      object is required in the referent namespace
+                                      to allow that namespace's owner to accept the
+                                      reference. See the ReferenceGrant documentation
+                                      for details. \n Support: Core"
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Port specifies the destination port
+                                      number to use for this resource. Port is required
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                            required:
+                            - backendRef
+                            type: object
+                          responseHeaderModifier:
+                            description: "ResponseHeaderModifier defines a schema
+                              for a filter that modifies response headers. \n Support:
+                              Extended"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input: GET /foo HTTP/1.1 my-header: foo
+                                  \n Config: add: - name: \"my-header\" value: \"bar,baz\"
+                                  \n Output: GET /foo HTTP/1.1 my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input: GET /foo HTTP/1.1 my-header1: foo my-header2:
+                                  bar my-header3: baz \n Config: remove: [\"my-header1\",
+                                  \"my-header3\"] \n Output: GET /foo HTTP/1.1 my-header2:
+                                  bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input: GET /foo HTTP/1.1 my-header: foo \n Config:
+                                  set: - name: \"my-header\" value: \"bar\" \n Output:
+                                  GET /foo HTTP/1.1 my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.
+                              As with other API fields, types are classified into
+                              three conformance levels: \n - Core: Filter types and
+                              their corresponding configuration defined by \"Support:
+                              Core\" in this package, e.g. \"RequestHeaderModifier\".
+                              All implementations supporting GRPCRoute MUST support
+                              core filters. \n - Extended: Filter types and their
+                              corresponding configuration defined by \"Support: Extended\"
+                              in this package, e.g. \"RequestMirror\". Implementers
+                              are encouraged to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by specific vendors.
+                              In the future, filters showing convergence in behavior
+                              across multiple implementations will be considered for
+                              inclusion in extended or core conformance levels. Filter-specific
+                              configuration for such filters is specified using the
+                              ExtensionRef field. `Type` MUST be set to \"ExtensionRef\"
+                              for custom filters. \n Implementers are encouraged to
+                              define custom implementation types to extend the core
+                              API with implementation-specific behavior. \n If a reference
+                              to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have
+                              been processed by that filter MUST receive a HTTP error
+                              response. \n "
+                            enum:
+                            - ResponseHeaderModifier
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                    matches:
+                      description: "Matches define conditions used for matching the
+                        rule against incoming gRPC requests. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. \n For example, take the following matches configuration:
+                        \n ``` matches: - method: service: foo.bar headers: values:
+                        version: 2 - method: service: foo.bar.v2 ``` \n For a request
+                        to match against this rule, it MUST satisfy EITHER of the
+                        two conditions: \n - service of foo.bar AND contains the header
+                        `version: 2` - service of foo.bar.v2 \n See the documentation
+                        for GRPCRouteMatch on how to specify multiple match conditions
+                        to be ANDed together. \n If no matches are specified, the
+                        implementation MUST match every gRPC request. \n Proxy or
+                        Load Balancer routing configuration generated from GRPCRoutes
+                        MUST prioritize rules based on the following criteria, continuing
+                        on ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
+                        Precedence MUST be given to the rule with the largest number
+                        of: \n * Characters in a matching non-wildcard hostname. *
+                        Characters in a matching hostname. * Characters in a matching
+                        service. * Characters in a matching method. * Header matches.
+                        \n If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
+                        \n If ties still exist within the Route that has been given
+                        precedence, matching precedence MUST be granted to the first
+                        matching rule meeting the above criteria."
+                      items:
+                        description: "GRPCRouteMatch defines the predicate used to
+                          match requests to a given action. Multiple match types are
+                          ANDed together, i.e. the match will evaluate to true only
+                          if all conditions are satisfied. \n For example, the match
+                          below will match a gRPC request only if its service is `foo`
+                          AND it contains the `version: v1` header: \n ``` matches:
+                          - method: type: Exact service: \"foo\" headers: - name:
+                          \"version\" value \"v1\" \n ```"
+                        properties:
+                          headers:
+                            description: Headers specifies gRPC request header matchers.
+                              Multiple match values are ANDed together, meaning, a
+                              request MUST match all the specified headers to select
+                              the route.
+                            items:
+                              description: GRPCHeaderMatch describes how to select
+                                a gRPC route by matching gRPC request headers.
+                              properties:
+                                name:
+                                  description: "Name is the name of the gRPC Header
+                                    to be matched. \n If multiple entries specify
+                                    equivalent header names, only the first entry
+                                    with an equivalent name MUST be considered for
+                                    a match. Subsequent entries with an equivalent
+                                    header name MUST be ignored. Due to the case-insensitivity
+                                    of header names, \"foo\" and \"Foo\" are considered
+                                    equivalent."
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: Type specifies how to match against
+                                    the value of the header.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of the gRPC Header
+                                    to be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: Method specifies a gRPC request service/method
+                              matcher. If this field is not specified, all services
+                              and methods will match.
+                            properties:
+                              method:
+                                description: "Value of the method to match against.
+                                  If left empty or omitted, will match all services.
+                                  \n At least one of Service and Method MUST be a
+                                  non-empty string."
+                                maxLength: 1024
+                                type: string
+                              service:
+                                description: "Value of the service to match against.
+                                  If left empty or omitted, will match any service.
+                                  \n At least one of Service and Method MUST be a
+                                  non-empty string."
+                                maxLength: 1024
+                                type: string
+                              type:
+                                default: Exact
+                                description: "Type specifies how to match against
+                                  the service and/or method. Support: Core (Exact
+                                  with service and method specified) \n Support: Implementation-specific
+                                  (Exact with method specified but no service specified)
+                                  \n Support: Implementation-specific (RegularExpression)"
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: One or both of 'service' or 'method' must be
+                                specified
+                              rule: 'has(self.type) ? has(self.service) || has(self.method)
+                                : true'
+                            - message: service must only contain valid characters
+                                (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.service) ? self.service.matches(r"""^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$"""):
+                                true'
+                            - message: method must only contain valid characters (matching
+                                ^[A-Za-z_][A-Za-z_0-9]*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
+                                true'
+                        type: object
+                      maxItems: 8
+                      type: array
+                  type: object
+                maxItems: 16
+                type: array
+            type: object
+          status:
+            description: Status defines the current state of GRPCRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile, experimental, ClusterIP Services
+                            only) \n Support for other resources is Implementation-Specific."
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. * Service: Port Name.
+                            When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services
+                            as Parents is part of experimental Mesh support and is
+                            not supported for any other purpose. \n Implementations
+                            MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
+    gateway.networking.k8s.io/bundle-version: v0.8.1
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:
@@ -2262,6 +3967,36 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n "
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     sectionName:
                       description: "SectionName is the name of a section within the
                         target resource. In the following resources, SectionName is
@@ -2295,26 +4030,31 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
-                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    == p2.kind && p1.name == p2.name && ( ( (!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
-                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? (((!has(p1.sectionName)
+                    == '''') ) || ( has(p1.__namespace__) && has(p2.__namespace__)
+                    && p1.__namespace__ == p2.__namespace__ ) ) ? ( ( ( (!has(p1.sectionName)
                     || p1.sectionName == '''') && (!has(p2.sectionName) || p2.sectionName
-                    == '''')) || (has(p1.sectionName) && p1.sectionName != '''' &&
-                    has(p2.sectionName) && p2.sectionName != '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0) ) || ( ( (has(p1.sectionName) && p1.sectionName
+                    != '''') || (has(p1.port) && p1.port != 0) ) && ( (has(p2.sectionName)
+                    && p2.sectionName != '''') || (has(p2.port) && p2.port != 0) )
+                    ) ) ): true ))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
                 default:
                 - matches:
@@ -4362,6 +6102,38 @@ spec:
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
                         sectionName:
                           description: "SectionName is the name of a section within
                             the target resource. In the following resources, SectionName
@@ -4594,6 +6366,36 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n "
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     sectionName:
                       description: "SectionName is the name of a section within the
                         target resource. In the following resources, SectionName is
@@ -4627,26 +6429,31 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
-                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    == p2.kind && p1.name == p2.name && ( ( (!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
-                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? (((!has(p1.sectionName)
+                    == '''') ) || ( has(p1.__namespace__) && has(p2.__namespace__)
+                    && p1.__namespace__ == p2.__namespace__ ) ) ? ( ( ( (!has(p1.sectionName)
                     || p1.sectionName == '''') && (!has(p2.sectionName) || p2.sectionName
-                    == '''')) || (has(p1.sectionName) && p1.sectionName != '''' &&
-                    has(p2.sectionName) && p2.sectionName != '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0) ) || ( ( (has(p1.sectionName) && p1.sectionName
+                    != '''') || (has(p1.port) && p1.port != 0) ) && ( (has(p2.sectionName)
+                    && p2.sectionName != '''') || (has(p2.port) && p2.port != 0) )
+                    ) ) ): true ))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
                 default:
                 - matches:
@@ -6694,6 +8501,38 @@ spec:
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
                         sectionName:
                           description: "SectionName is the name of a section within
                             the target resource. In the following resources, SectionName
@@ -6750,7 +8589,7 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+# config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6758,7 +8597,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
     gateway.networking.k8s.io/bundle-version: v0.8.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
 spec:
@@ -7037,3 +8876,2183 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
+    gateway.networking.k8s.io/bundle-version: v0.8.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tcproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: TCPRoute provides a way to route TCP requests. When combined
+          with a Gateway listener, it can be used to forward connections on the port
+          specified by the listener to a set of backends specified by the TCPRoute.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only) \n This
+                  API may be extended in the future to support additional kinds of
+                  parent resources. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. \n ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route. \n "
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile, experimental, ClusterIP Services only)
+                    \n This API may be extended in the future to support additional
+                    kinds of parent resources. \n The API object must be valid in
+                    the cluster; the Group and Kind must be registered in the cluster
+                    for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile, experimental, ClusterIP Services only) \n Support
+                        for other resources is Implementation-Specific."
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        \n ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n "
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. * Service: Port Name. When both Port (experimental)
+                        and SectionName are specified, the name and port of the selected
+                        listener must match both specified values. Note that attaching
+                        Routes to Services as Parents is part of experimental Mesh
+                        support and is not supported for any other purpose. \n Implementations
+                        MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName
+                        is interpreted. \n When unspecified (empty string), this will
+                        reference the entire resource. For the purpose of status,
+                        an attachment is considered successful if at least one section
+                        in the parent resource accepts it. For example, Gateway listeners
+                        can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from the referencing Route, the Route MUST be considered
+                        successfully attached. If no Gateway listeners accept attachment
+                        from this Route, the Route MUST be considered detached from
+                        the Gateway. \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && ( ( (!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''') ) || ( has(p1.__namespace__) && has(p2.__namespace__)
+                    && p1.__namespace__ == p2.__namespace__ ) ) ? ( ( ( (!has(p1.sectionName)
+                    || p1.sectionName == '''') && (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0) ) || ( ( (has(p1.sectionName) && p1.sectionName
+                    != '''') || (has(p1.port) && p1.port != 0) ) && ( (has(p2.sectionName)
+                    && p2.sectionName != '''') || (has(p2.port) && p2.port != 0) )
+                    ) ) ): true ))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TCP matchers and actions.
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. If unspecified or invalid (refers
+                        to a non-existent resource or a Service with no endpoints),
+                        the underlying implementation MUST actively reject connection
+                        attempts to this backend. Connection rejections must respect
+                        weight; if an invalid backend is requested to have 80% of
+                        connections, then 80% of connections must be rejected instead.
+                        \n Support: Core for Kubernetes Service \n Support: Extended
+                        for Kubernetes ServiceImport \n Support: Implementation-specific
+                        for any other resource \n Support for weight: Extended"
+                      items:
+                        description: "BackendRef defines how a Route should forward
+                          a request to a Kubernetes resource. \n Note that when a
+                          namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace
+                          to allow that namespace's owner to accept the reference.
+                          See the ReferenceGrant documentation for details."
+                        properties:
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: "Kind is the Kubernetes resource kind of
+                              the referent. For example \"Service\". \n Defaults to
+                              \"Service\" when not specified. \n ExternalName services
+                              can refer to CNAME DNS records that may live outside
+                              of the cluster and as such are difficult to reason about
+                              in terms of conformance. They also may not be safe to
+                              forward to (see CVE-2021-25740 for more information).
+                              Implementations SHOULD NOT support ExternalName Services.
+                              \n Support: Core (Services with a type other than ExternalName)
+                              \n Support: Implementation-specific (Services with type
+                              ExternalName)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace different than the local
+                              namespace is specified, a ReferenceGrant object is required
+                              in the referent namespace to allow that namespace's
+                              owner to accept the reference. See the ReferenceGrant
+                              documentation for details. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile, experimental, ClusterIP Services
+                            only) \n Support for other resources is Implementation-Specific."
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. * Service: Port Name.
+                            When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services
+                            as Parents is part of experimental Mesh support and is
+                            not supported for any other purpose. \n Implementations
+                            MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
+    gateway.networking.k8s.io/bundle-version: v0.8.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: "The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility in
+          matching streams for a given TLS listener. \n If you need to forward traffic
+          to a single target for a TLS listener, you could choose to use a TCPRoute
+          with a TLS listener."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of SNI names that should match
+                  against the SNI attribute of TLS ClientHello message in TLS handshake.
+                  This matches the RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed in SNI names per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The
+                  wildcard label must appear by itself as the first label. \n If a
+                  hostname is specified by both the Listener and TLSRoute, there must
+                  be at least one intersecting hostname for the TLSRoute to be attached
+                  to the Listener. For example: \n * A Listener with `test.example.com`
+                  as the hostname matches TLSRoutes that have either not specified
+                  any hostnames, or have specified at least one of `test.example.com`
+                  or `*.example.com`. * A Listener with `*.example.com` as the hostname
+                  matches TLSRoutes that have either not specified any hostnames or
+                  have specified at least one hostname that matches the Listener hostname.
+                  For example, `test.example.com` and `*.example.com` would both match.
+                  On the other hand, `example.com` and `test.example.net` would not
+                  match. \n If both the Listener and TLSRoute have specified hostnames,
+                  any TLSRoute hostnames that do not match the Listener hostname MUST
+                  be ignored. For example, if a Listener specified `*.example.com`,
+                  and the TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match. \n If both
+                  the Listener and TLSRoute have specified hostnames, and none match
+                  with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status
+                  of `False` in the corresponding RouteParentStatus. \n Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                    host. This matches the RFC 1123 definition of a hostname with
+                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard label
+                    must appear by itself as the first label. \n Hostname can be \"precise\"
+                    which is a domain name without the terminating dot of a network
+                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                    name prefixed with a single wildcard label (e.g. `*.example.com`).
+                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                    of lower case alphanumeric characters or '-', and must start and
+                    end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only) \n This
+                  API may be extended in the future to support additional kinds of
+                  parent resources. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. \n ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route. \n "
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile, experimental, ClusterIP Services only)
+                    \n This API may be extended in the future to support additional
+                    kinds of parent resources. \n The API object must be valid in
+                    the cluster; the Group and Kind must be registered in the cluster
+                    for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile, experimental, ClusterIP Services only) \n Support
+                        for other resources is Implementation-Specific."
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        \n ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n "
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. * Service: Port Name. When both Port (experimental)
+                        and SectionName are specified, the name and port of the selected
+                        listener must match both specified values. Note that attaching
+                        Routes to Services as Parents is part of experimental Mesh
+                        support and is not supported for any other purpose. \n Implementations
+                        MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName
+                        is interpreted. \n When unspecified (empty string), this will
+                        reference the entire resource. For the purpose of status,
+                        an attachment is considered successful if at least one section
+                        in the parent resource accepts it. For example, Gateway listeners
+                        can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from the referencing Route, the Route MUST be considered
+                        successfully attached. If no Gateway listeners accept attachment
+                        from this Route, the Route MUST be considered detached from
+                        the Gateway. \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && ( ( (!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''') ) || ( has(p1.__namespace__) && has(p2.__namespace__)
+                    && p1.__namespace__ == p2.__namespace__ ) ) ? ( ( ( (!has(p1.sectionName)
+                    || p1.sectionName == '''') && (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0) ) || ( ( (has(p1.sectionName) && p1.sectionName
+                    != '''') || (has(p1.port) && p1.port != 0) ) && ( (has(p2.sectionName)
+                    && p2.sectionName != '''') || (has(p2.port) && p2.port != 0) )
+                    ) ) ): true ))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. If unspecified or invalid (refers
+                        to a non-existent resource or a Service with no endpoints),
+                        the rule performs no forwarding; if no filters are specified
+                        that would result in a response being sent, the underlying
+                        implementation must actively reject request attempts to this
+                        backend, by rejecting the connection or returning a 500 status
+                        code. Request rejections must respect weight; if an invalid
+                        backend is requested to have 80% of requests, then 80% of
+                        requests must be rejected instead. \n Support: Core for Kubernetes
+                        Service \n Support: Extended for Kubernetes ServiceImport
+                        \n Support: Implementation-specific for any other resource
+                        \n Support for weight: Extended"
+                      items:
+                        description: "BackendRef defines how a Route should forward
+                          a request to a Kubernetes resource. \n Note that when a
+                          namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace
+                          to allow that namespace's owner to accept the reference.
+                          See the ReferenceGrant documentation for details."
+                        properties:
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: "Kind is the Kubernetes resource kind of
+                              the referent. For example \"Service\". \n Defaults to
+                              \"Service\" when not specified. \n ExternalName services
+                              can refer to CNAME DNS records that may live outside
+                              of the cluster and as such are difficult to reason about
+                              in terms of conformance. They also may not be safe to
+                              forward to (see CVE-2021-25740 for more information).
+                              Implementations SHOULD NOT support ExternalName Services.
+                              \n Support: Core (Services with a type other than ExternalName)
+                              \n Support: Implementation-specific (Services with type
+                              ExternalName)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace different than the local
+                              namespace is specified, a ReferenceGrant object is required
+                              in the referent namespace to allow that namespace's
+                              owner to accept the reference. See the ReferenceGrant
+                              documentation for details. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile, experimental, ClusterIP Services
+                            only) \n Support for other resources is Implementation-Specific."
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. * Service: Port Name.
+                            When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services
+                            as Parents is part of experimental Mesh support and is
+                            not supported for any other purpose. \n Implementations
+                            MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
+    gateway.networking.k8s.io/bundle-version: v0.8.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: udproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: UDPRoute
+    listKind: UDPRouteList
+    plural: udproutes
+    singular: udproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: UDPRoute provides a way to route UDP traffic. When combined with
+          a Gateway listener, it can be used to forward traffic on the port specified
+          by the listener to a set of backends specified by the UDPRoute.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only) \n This
+                  API may be extended in the future to support additional kinds of
+                  parent resources. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. \n ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route. \n "
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile, experimental, ClusterIP Services only)
+                    \n This API may be extended in the future to support additional
+                    kinds of parent resources. \n The API object must be valid in
+                    the cluster; the Group and Kind must be registered in the cluster
+                    for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile, experimental, ClusterIP Services only) \n Support
+                        for other resources is Implementation-Specific."
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        \n ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n "
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. * Service: Port Name. When both Port (experimental)
+                        and SectionName are specified, the name and port of the selected
+                        listener must match both specified values. Note that attaching
+                        Routes to Services as Parents is part of experimental Mesh
+                        support and is not supported for any other purpose. \n Implementations
+                        MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName
+                        is interpreted. \n When unspecified (empty string), this will
+                        reference the entire resource. For the purpose of status,
+                        an attachment is considered successful if at least one section
+                        in the parent resource accepts it. For example, Gateway listeners
+                        can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from the referencing Route, the Route MUST be considered
+                        successfully attached. If no Gateway listeners accept attachment
+                        from this Route, the Route MUST be considered detached from
+                        the Gateway. \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && ( ( (!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''') ) || ( has(p1.__namespace__) && has(p2.__namespace__)
+                    && p1.__namespace__ == p2.__namespace__ ) ) ? ( ( ( (!has(p1.sectionName)
+                    || p1.sectionName == '''') && (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0) ) || ( ( (has(p1.sectionName) && p1.sectionName
+                    != '''') || (has(p1.port) && p1.port != 0) ) && ( (has(p2.sectionName)
+                    && p2.sectionName != '''') || (has(p2.port) && p2.port != 0) )
+                    ) ) ): true ))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of UDP matchers and actions.
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. If unspecified or invalid (refers
+                        to a non-existent resource or a Service with no endpoints),
+                        the underlying implementation MUST actively reject connection
+                        attempts to this backend. Packet drops must respect weight;
+                        if an invalid backend is requested to have 80% of the packets,
+                        then 80% of packets must be dropped instead. \n Support: Core
+                        for Kubernetes Service \n Support: Extended for Kubernetes
+                        ServiceImport \n Support: Implementation-specific for any
+                        other resource \n Support for weight: Extended"
+                      items:
+                        description: "BackendRef defines how a Route should forward
+                          a request to a Kubernetes resource. \n Note that when a
+                          namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace
+                          to allow that namespace's owner to accept the reference.
+                          See the ReferenceGrant documentation for details."
+                        properties:
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: "Kind is the Kubernetes resource kind of
+                              the referent. For example \"Service\". \n Defaults to
+                              \"Service\" when not specified. \n ExternalName services
+                              can refer to CNAME DNS records that may live outside
+                              of the cluster and as such are difficult to reason about
+                              in terms of conformance. They also may not be safe to
+                              forward to (see CVE-2021-25740 for more information).
+                              Implementations SHOULD NOT support ExternalName Services.
+                              \n Support: Core (Services with a type other than ExternalName)
+                              \n Support: Implementation-specific (Services with type
+                              ExternalName)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace different than the local
+                              namespace is specified, a ReferenceGrant object is required
+                              in the referent namespace to allow that namespace's
+                              owner to accept the reference. See the ReferenceGrant
+                              documentation for details. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile, experimental, ClusterIP Services
+                            only) \n Support for other resources is Implementation-Specific."
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. * Service: Port Name.
+                            When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services
+                            as Parents is part of experimental Mesh support and is
+                            not supported for any other purpose. \n Implementations
+                            MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/webhook/0-namespace.yaml
+#
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-system
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+#
+# config/webhook/admission_webhook.yaml
+#
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: gateway-api-admission
+webhooks:
+- name: validate.gateway.networking.k8s.io
+  matchPolicy: Equivalent
+  rules:
+  - operations: [ "CREATE" , "UPDATE" ]
+    apiGroups: [ "gateway.networking.k8s.io" ]
+    apiVersions: [ "v1alpha2", "v1beta1" ]
+    resources: [ "gateways", "gatewayclasses", "httproutes" ]
+  failurePolicy: Fail
+  sideEffects: None
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: gateway-api-admission-server
+      namespace: gateway-system
+      path: "/validate"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: gateway-api-webhook-server
+  name: gateway-api-admission-server
+  namespace: gateway-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    name: gateway-api-admission-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-api-admission-server
+  namespace: gateway-system
+  labels:
+    name: gateway-api-admission-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: gateway-api-admission-server
+  template:
+    metadata:
+      name: gateway-api-admission-server
+      labels:
+        name: gateway-api-admission-server
+    spec:
+      containers:
+      - name: webhook
+        image: registry.k8s.io/gateway-api/admission-server:v0.8.1
+        imagePullPolicy: IfNotPresent
+        args:
+        - -logtostderr
+        - --tlsCertFile=/etc/certs/cert
+        - --tlsKeyFile=/etc/certs/key
+        - -v=10
+        - 2>&1
+        ports:
+        - containerPort: 8443
+          name: webhook
+        resources:
+          limits:
+            memory: 50Mi
+            cpu: 100m
+          requests:
+            memory: 50Mi
+            cpu: 100m
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /etc/certs
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
+          capabilities:
+            drop:
+            - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: gateway-api-admission
+---
+#
+# config/webhook/certificate_config.yaml
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-api-admission
+  labels:
+    name: gateway-api-webhook
+  namespace: gateway-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gateway-api-admission
+  labels:
+    name: gateway-api
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-api-admission
+  annotations:
+  labels:
+    name: gateway-api-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gateway-api-admission
+subjects:
+- kind: ServiceAccount
+  name: gateway-api-admission
+  namespace: gateway-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-api-admission
+  annotations:
+  labels:
+    name: gateway-api-webhook
+  namespace: gateway-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-api-admission
+  annotations:
+  labels:
+    name: gateway-api-webhook
+  namespace: gateway-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gateway-api-admission
+subjects:
+- kind: ServiceAccount
+  name: gateway-api-admission
+  namespace: gateway-system
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-api-admission
+  annotations:
+  labels:
+    name: gateway-api-webhook
+  namespace: gateway-system
+spec:
+  template:
+    metadata:
+      name: gateway-api-admission-create
+      labels:
+        name: gateway-api-webhook
+    spec:
+      containers:
+      - name: create
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+        imagePullPolicy: IfNotPresent
+        args:
+        - create
+        - --host=gateway-api-admission-server,gateway-api-admission-server.$(POD_NAMESPACE).svc
+        - --namespace=$(POD_NAMESPACE)
+        - --secret-name=gateway-api-admission
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          capabilities:
+            drop:
+            - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
+      restartPolicy: OnFailure
+      serviceAccountName: gateway-api-admission
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        runAsGroup: 2000
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-api-admission-patch
+  labels:
+    name: gateway-api-webhook
+  namespace: gateway-system
+spec:
+  template:
+    metadata:
+      name: gateway-api-admission-patch
+      labels:
+        name: gateway-api-webhook
+    spec:
+      containers:
+      - name: patch
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+        imagePullPolicy: IfNotPresent
+        args:
+        - patch
+        - --webhook-name=gateway-api-admission
+        - --namespace=$(POD_NAMESPACE)
+        - --patch-mutating=false
+        - --patch-validating=true
+        - --secret-name=gateway-api-admission
+        - --patch-failure-policy=Fail
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          capabilities:
+            drop:
+            - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
+      restartPolicy: OnFailure
+      serviceAccountName: gateway-api-admission
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        runAsGroup: 2000

--- a/test/gateway-api/resources.yml
+++ b/test/gateway-api/resources.yml
@@ -5,15 +5,15 @@ metadata:
   name: gateway-one
   namespace: default
 spec:
-  gatewayClassName: "istio"
+  gatewayClassName: istio
   listeners:
-  - name: default
-    hostname: "*.gw.foo.org"
-    port: 80
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: All
+    - name: default
+      hostname: "*.gw.foo.org"
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
@@ -21,15 +21,15 @@ metadata:
   name: gateway-two
   namespace: default
 spec:
-  gatewayClassName: "istio"
+  gatewayClassName: istio
   listeners:
-  - name: default
-    hostname: "*.gw.foo.org"
-    port: 80
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: All
+    - name: default
+      hostname: "*.gw.foo.org"
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
@@ -38,16 +38,16 @@ metadata:
   namespace: default
 spec:
   parentRefs:
-  - name: gateway-one
+    - name: gateway-one
   hostnames: ["myservicea.gw.foo.org"]
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: backend
-      port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 80
 
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -57,17 +57,17 @@ metadata:
   namespace: kube-system
 spec:
   parentRefs:
-  - name: gateway-one
-    namespace: default
+    - name: gateway-one
+      namespace: default
   hostnames: ["myserviceb.gw.foo.org"]
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: backend
-      port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 80
 
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -77,17 +77,17 @@ metadata:
   namespace: kube-system
 spec:
   parentRefs:
-  - name: gatewayWrong
-    namespace: default
+    - name: gatewayWrong
+      namespace: default
   hostnames: ["myservicec.gw.foo.org"]
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: backend
-      port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
@@ -96,14 +96,50 @@ metadata:
   namespace: default
 spec:
   parentRefs:
-  - name: gateway-one
-  - name: gateway-two
+    - name: gateway-one
+    - name: gateway-two
   hostnames: ["myserviced.gw.foo.org"]
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: backend
-      port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: myservicetls
+  namespace: default
+spec:
+  parentRefs:
+    - name: gateway-one
+  hostnames: ["myservicetls.gw.foo.org"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GRPCRoute
+metadata:
+  name: myservicegrpc
+  namespace: default
+spec:
+  parentRefs:
+    - name: gateway-one
+  hostnames: ["myservicegrpc.gw.foo.org"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 443

--- a/test/gatewayclasses.yaml
+++ b/test/gatewayclasses.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: cilium
+spec:
+  controllerName: "cilium.io/ingress-controller"
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: nginx
+spec:
+  controllerName: "k8s.io/ingress-nginx"
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: nginxinc-gateway
+spec:
+  controllerName: "nginx.org/ingress-controller"

--- a/test/kind-with-registry.sh
+++ b/test/kind-with-registry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Adapted from:
 # https://github.com/kubernetes-sigs/kind/commits/master/site/static/examples/kind-with-registry.sh
@@ -62,6 +62,7 @@ nodes:
     protocol: UDP
 networking:
   ipFamily: dual
+  disableDefaultCNI: true
 EOF
 
 cat <<EOF | kubectl apply -f -

--- a/test/metallb-values.yaml
+++ b/test/metallb-values.yaml
@@ -1,7 +1,0 @@
-configInline:
-  address-pools:
-   - name: default
-     protocol: layer2
-     addresses:
-     - 198.51.100.0/24
-     - fd12:3456:789a:1::/64

--- a/test/nginxinc-kubernetes-ingress/values.yaml
+++ b/test/nginxinc-kubernetes-ingress/values.yaml
@@ -1,3 +1,4 @@
 controller:
   enableCustomResources: true
-  ingressClass: nginxinc
+  ingressClass:
+    name: nginxinc

--- a/test/single-stack/ingress-services.yml
+++ b/test/single-stack/ingress-services.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-myservicea
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: myservicea.foo.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: default
+spec:
+  ports:
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: backend
+  sessionAffinity: None
+  type: LoadBalancer

--- a/test/single-stack/k8s-gateway-values.yaml
+++ b/test/single-stack/k8s-gateway-values.yaml
@@ -4,6 +4,12 @@ image:
   repository: coredns
   tag: latest
 
+watchedResources:
+  - HTTPRoute
+  - TLSRoute
+  - GRPCRoute
+  - Ingress
+  - Service
 # Delegated domain
 domain: "foo.org"
 
@@ -16,7 +22,6 @@ service:
   # externalTrafficPolicy: Local
   # externalIPs:
   #  - 192.168.1.3
-  ipFamilyPolicy: RequireDualStack
 
 debug:
   enabled: true

--- a/test/single-stack/service-annotation.yml
+++ b/test/single-stack/service-annotation.yml
@@ -7,12 +7,11 @@ metadata:
   annotations:
     "coredns.io/hostname": "good.ok"
 spec:
-  ipFamilyPolicy: RequireDualStack
   ports:
-  - name: 80-80
-    port: 80
-    protocol: TCP
-    targetPort: 80
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
   selector:
     app: backend
   sessionAffinity: None
@@ -26,12 +25,11 @@ metadata:
   annotations:
     "coredns.io/hostname": "abcd0123456789012345678901234567890123456789012345678901234567890"
 spec:
-  ipFamilyPolicy: RequireDualStack
   ports:
-  - name: 80-80
-    port: 80
-    protocol: TCP
-    targetPort: 80
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
   selector:
     app: backend
   sessionAffinity: None
@@ -45,12 +43,11 @@ metadata:
   annotations:
     "coredns.io/hostname": "foo_bar"
 spec:
-  ipFamilyPolicy: RequireDualStack
   ports:
-  - name: 80-80
-    port: 80
-    protocol: TCP
-    targetPort: 80
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
   selector:
     app: backend
   sessionAffinity: None


### PR DESCRIPTION
- use experimental install crds, for tests
- add tests for tls and grpc

would close #237 
