### PR TITLE
fix: Increase golangci-lint timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54.2
-          args: --timeout=2m30s
+          args: --timeout=5m0s
 
   unit-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 
 .PHONY: ci
 ci:
-	 golangci-lint run  --timeout=2m30s
+	 golangci-lint run --timeout=5m0s
 
 clean:
 	go clean


### PR DESCRIPTION
Follow up to https://github.com/ori-edge/k8s_gateway/pull/234

This increases `golangci-lint` timeout to 5 minutes as CI is not fast enough on an uncached run.

cc/ @networkop 