### PR TITLE
Helm chart: allow custom service labels

### DIFF
--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: 0.4.0
 maintainers:
   - email: mmkashin@gmail.com

--- a/charts/k8s-gateway/templates/service.yaml
+++ b/charts/k8s-gateway/templates/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: {{ include "k8s-gateway.fullname" . }}
   labels:
+{{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+{{- end }}
     {{- include "k8s-gateway.labels" . | nindent 4 }}
   annotations:
 {{- if .Values.service.annotations }}

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -62,6 +62,7 @@ service:
   type: LoadBalancer
   port: 53
   annotations: {}
+  labels: {}
   # nodePort: 30053
   # loadBalancerIP: 192.168.1.2
   # clusterIP: 10.43.0.53


### PR DESCRIPTION
In addition to annotations, for my use case involving `matchLabels` it would be helpful to be able to add additional labels to the Service. This PR adds a `service.labels` value to the Helm chart to allow custom labels. The implementation copies that of `service.annotations`.