### PR TITLE
Avoid changing all chart timestamps when updating Helm index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor
 coredns
 tilt_modules
+*.tmp
 .helm
 .vscode
 .idea

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,12 @@ build:
 
 ## Generate new helm package and update chart yaml file
 helm-update:
-	helm package charts/k8s-gateway -d charts/
-	helm repo index --url https://ori-edge.github.io/k8s_gateway/ --merge index.yaml .
+	helm package charts/k8s-gateway -d charts.tmp/charts
+	helm repo index --url https://ori-edge.github.io/k8s_gateway/ --merge index.yaml charts.tmp/
+	mv charts.tmp/charts/* charts/
+	mv charts.tmp/index.yaml .
+	rmdir charts.tmp/charts
+	rmdir charts.tmp
 
 .PHONY: test
 test:

--- a/index.yaml
+++ b/index.yaml
@@ -16,7 +16,7 @@ entries:
     version: 2.1.0
   - apiVersion: v2
     appVersion: 0.3.4
-    created: "2023-11-28T19:36:56.0889706Z"
+    created: "2023-05-18T21:58:11.720451-10:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: d84849d390d9f42daa2dd60b61c1455cf8e38ed99e0c0dc2f0acb117b346a021
     maintainers:
@@ -29,7 +29,7 @@ entries:
     version: 2.0.4
   - apiVersion: v2
     appVersion: 0.3.4
-    created: "2023-11-28T19:36:56.08851133Z"
+    created: "2023-04-01T00:28:14.446951+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: a21d3fb52cb21eca2f6f32b8a1b662fa9c6c48bafd3b33b336e724f28ca39a70
     maintainers:
@@ -42,7 +42,7 @@ entries:
     version: 2.0.3
   - apiVersion: v2
     appVersion: 0.3.3
-    created: "2023-11-28T19:36:56.088119378Z"
+    created: "2023-02-08T13:43:25.923981205+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: b941f63f09fc65855967eb890ba556075df9d42c04fc21b18836c0011a5a8229
     maintainers:
@@ -55,7 +55,7 @@ entries:
     version: 2.0.2
   - apiVersion: v2
     appVersion: 0.3.3
-    created: "2023-11-28T19:36:56.087740906Z"
+    created: "2023-01-25T13:16:37.2554671Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: b96df1c4198087fa34f293ca0ad2d4372d2066a31c26fea981e3fe4f4a8abfea
     maintainers:
@@ -68,7 +68,7 @@ entries:
     version: 2.0.1
   - apiVersion: v2
     appVersion: 0.3.2
-    created: "2023-11-28T19:36:56.087334521Z"
+    created: "2022-10-06T18:32:18.790811167-04:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 44008b4017ffb7230022c6228921c097f85313f629f6684bfd0136e70db0ff41
     maintainers:
@@ -81,7 +81,7 @@ entries:
     version: 2.0.0
   - apiVersion: v2
     appVersion: 0.3.2
-    created: "2023-11-28T19:36:56.083862005Z"
+    created: "2022-09-16T06:55:51.464068-10:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: cc88bce8cd2e40d8c65ba50cb48e13aafc2f6e2abe582ee055c935635b8b594a
     maintainers:
@@ -94,7 +94,7 @@ entries:
     version: 1.1.15
   - apiVersion: v2
     appVersion: 0.3.2
-    created: "2023-11-28T19:36:56.083282348Z"
+    created: "2022-09-07T09:26:26.3140647+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: fd02dc1f1642fe6f3a48b9c0982b253c4c373910f962c76448f3efac6b30f31c
     maintainers:
@@ -107,7 +107,7 @@ entries:
     version: 1.1.14
   - apiVersion: v2
     appVersion: 0.3.1
-    created: "2023-11-28T19:36:56.081130421Z"
+    created: "2022-08-26T11:28:08.2393611+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: ceea643a6515e4a7caa473a54cdfff55a5ad02f4520392eecf22767c94ac7402
     maintainers:
@@ -120,7 +120,7 @@ entries:
     version: 1.1.13
   - apiVersion: v2
     appVersion: 0.3.1
-    created: "2023-11-28T19:36:56.080593711Z"
+    created: "2022-08-10T11:06:15.444994645+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 56090b3f30d6d8a9b7ebfeed1a58bc058266794dc41160018342ff32a620a706
     maintainers:
@@ -133,7 +133,7 @@ entries:
     version: 1.1.12
   - apiVersion: v2
     appVersion: 0.3.1
-    created: "2023-11-28T19:36:56.080075231Z"
+    created: "2022-08-02T11:30:03.7284941+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: ccab0ddbe46efbfd92de6317d2643e2bf25a55db1c5dfd7b73cff943c07c0aa5
     maintainers:
@@ -146,7 +146,7 @@ entries:
     version: 1.1.11
   - apiVersion: v2
     appVersion: 0.3.1
-    created: "2023-11-28T19:36:56.07959425Z"
+    created: "2022-08-02T11:14:52.2985453+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 62d07bba3428f6a68274d77906f490763bbbeafbd270befbd02c4754601f3239
     maintainers:
@@ -159,7 +159,7 @@ entries:
     version: 1.1.10
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2023-11-28T19:36:56.086743671Z"
+    created: "2022-05-14T15:14:29.8966439+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 336534b4748dd88c9d4e829d9a8527696b5369e4814c3e18c202f12198e7ba97
     maintainers:
@@ -172,7 +172,7 @@ entries:
     version: 1.1.9
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2023-11-28T19:36:56.086254303Z"
+    created: "2022-05-14T15:00:36.5389617+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: a856c5b4f473790627848bc472393ade5f9771b66b2dd660d19312763bdfd4a5
     maintainers:
@@ -185,7 +185,7 @@ entries:
     version: 1.1.8
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2023-11-28T19:36:56.085884896Z"
+    created: "2022-05-03T10:17:09.8492852+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 5fc39d5e8ad2f64545e747e82d1a097115f1b95fc76405791351c653ef3f1fde
     maintainers:
@@ -198,7 +198,7 @@ entries:
     version: 1.1.7
   - apiVersion: v2
     appVersion: 0.2.4
-    created: "2023-11-28T19:36:56.085519066Z"
+    created: "2022-03-26T15:26:13.1609365Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: f66d0497f55b9dda1bc8145de86f6a1042476482b6849ba05fa019c66bdb8fd2
     maintainers:
@@ -211,7 +211,7 @@ entries:
     version: 1.1.6
   - apiVersion: v2
     appVersion: 0.2.3
-    created: "2023-11-28T19:36:56.085167491Z"
+    created: "2022-03-26T09:18:08.5827058Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 3be4dd3ee183c4cec91bd0a40c08b7114ebc5a3a8153621a7432af11592ddb29
     maintainers:
@@ -224,7 +224,7 @@ entries:
     version: 1.1.5
   - apiVersion: v2
     appVersion: 0.2.2
-    created: "2023-11-28T19:36:56.084801817Z"
+    created: "2022-03-25T12:27:54.64261986-07:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 9889676767632d7634236e79338fd6877a37d1dc7a56e9f32cb00b1b78589814
     maintainers:
@@ -237,7 +237,7 @@ entries:
     version: 1.1.4
   - apiVersion: v2
     appVersion: 0.2.2
-    created: "2023-11-28T19:36:56.084361672Z"
+    created: "2022-01-23T16:12:23.7932869Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: b82cc1cd106db91b03ce9249176a3b8c58ffa70ed83f4bab907910a041e04620
     maintainers:
@@ -250,7 +250,7 @@ entries:
     version: 1.1.2
   - apiVersion: v2
     appVersion: 0.2.1
-    created: "2023-11-28T19:36:56.079100895Z"
+    created: "2022-01-14T11:12:45.5088678Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: a6946aa35fed1b67ab968d282cc0cbbbb3136c6781563df7496b78e6e88ca8e1
     maintainers:
@@ -263,7 +263,7 @@ entries:
     version: 1.1.1
   - apiVersion: v2
     appVersion: 0.2.0
-    created: "2023-11-28T19:36:56.078685915Z"
+    created: "2022-01-13T16:49:24.5393117Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 74abb009602b062b805dbd96fb07cbd4c725e8dee7cd980bab0149fba1030c3a
     maintainers:
@@ -276,7 +276,7 @@ entries:
     version: 1.1.0
   - apiVersion: v2
     appVersion: 0.1.8
-    created: "2023-11-28T19:36:56.075089813Z"
+    created: "2021-11-22T21:54:20.605601411+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: df847a43e164794eb49a0d4d2d81657dd4043524862f369ae995b2b70ecbb105
     maintainers:
@@ -289,7 +289,7 @@ entries:
     version: 1.0.12
   - apiVersion: v2
     appVersion: 0.1.8
-    created: "2023-11-28T19:36:56.07434683Z"
+    created: "2021-10-20T14:36:53.024906003Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 2d1fe6ac3011d03642a77ddaa3cbe9cc7a99f19226f33f4ae18ca0d413155c0e
     maintainers:
@@ -302,7 +302,7 @@ entries:
     version: 1.0.11
   - apiVersion: v2
     appVersion: 0.1.8
-    created: "2023-11-28T19:36:56.07386113Z"
+    created: "2021-09-19T14:19:06.1957688+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 796c8f7636ef4f33c43afb0ef947817ba4caa1ace29de3d903ee2fc831fd3edf
     maintainers:
@@ -315,7 +315,7 @@ entries:
     version: 1.0.10
   - apiVersion: v2
     appVersion: 0.1.8
-    created: "2023-11-28T19:36:56.078205998Z"
+    created: "2021-09-11T22:07:27.010685+02:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 8d194587b8f31ed6230b2b2fcb2215f3f52e0be1a8ff754007b5a94731b7bcfb
     maintainers:
@@ -328,7 +328,7 @@ entries:
     version: 1.0.9
   - apiVersion: v2
     appVersion: 0.1.8
-    created: "2023-11-28T19:36:56.077785401Z"
+    created: "2021-09-11T21:15:33.840636+02:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 8edd4edd05d76253b81ecfaafab51f171fa725bd81b6b26fef81efa26e9374d7
     maintainers:
@@ -341,7 +341,7 @@ entries:
     version: 1.0.8
   - apiVersion: v2
     appVersion: 0.1.8
-    created: "2023-11-28T19:36:56.077441188Z"
+    created: "2021-09-04T03:53:00.145401037Z"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: f162c5063236777b2cc238a03162e39ac2b2bbea46e0c31c6ae01eb88d9ce5c9
     maintainers:
@@ -354,7 +354,7 @@ entries:
     version: 1.0.7
   - apiVersion: v2
     appVersion: 0.1.8
-    created: "2023-11-28T19:36:56.077060598Z"
+    created: "2021-08-15T11:58:15.0783041+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: cb09166912e10c092c0f15ff5aee21e5f6a57d5ffc02047695991d0f7fc019d6
     maintainers:
@@ -367,7 +367,7 @@ entries:
     version: 1.0.6
   - apiVersion: v2
     appVersion: 0.1.7
-    created: "2023-11-28T19:36:56.076677268Z"
+    created: "2021-08-09T10:58:35.9945547+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 4941bcbfc5d054cf958befda1a65a2e32773aaddd59af4b2f9420353465f0be4
     maintainers:
@@ -380,7 +380,7 @@ entries:
     version: 1.0.5
   - apiVersion: v2
     appVersion: 0.1.6
-    created: "2023-11-28T19:36:56.076293042Z"
+    created: "2021-06-21T10:00:54.1126176+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 8753d366172031ce0386c50f6857c1ac6e1f094f9ed03ad01e33f3619c6e7880
     maintainers:
@@ -393,7 +393,7 @@ entries:
     version: 1.0.4
   - apiVersion: v2
     appVersion: 0.1.5
-    created: "2023-11-28T19:36:56.075901663Z"
+    created: "2021-04-28T10:58:56.930170706+02:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 2aa879712ad7ce33424b5f3477acf6a90480ba317e63dd1f343f4beac66b1c0e
     maintainers:
@@ -406,7 +406,7 @@ entries:
     version: 1.0.3
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2023-11-28T19:36:56.075458266Z"
+    created: "2021-04-25T11:21:58.936624015+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 145ce2e722a9d8c95f147a5d608e00a5c47addbaeb9ea4882491e1e185c949b4
     maintainers:
@@ -419,7 +419,7 @@ entries:
     version: 1.0.2
   - apiVersion: v2
     appVersion: 0.1.4
-    created: "2023-11-28T19:36:56.073393993Z"
+    created: "2021-04-09T11:05:37.670183343+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 8f780ec9b25ca9d4461c076203a7d31889499a134086df72ce26096f0eb71ce9
     maintainers:
@@ -432,7 +432,7 @@ entries:
     version: 1.0.1
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2023-11-28T19:36:56.072885471Z"
+    created: "2021-04-06T10:15:18.545674337+01:00"
     description: A Helm chart for the k8s_gateway CoreDNS plugin
     digest: 2744fcdd9840590cb9f86099135229ca2fd8b3a140bcf141a3ed206191dfd3f6
     maintainers:


### PR DESCRIPTION
When attempting to update the chart index in #256, I noticed that `make helm-release` completely rebuilds the Helm index file and updates the timestamp of every release, including existing ones. It's pretty insignificant, but it makes for a larger diff on chart updates so I wondered whether there was a good solution.

It turns out this is a known limitation in Helm (https://github.com/helm/helm/issues/7363) but can be solved pretty easily by isolating the new chart when computing the updated index, and then merging the existing index.

For completeness I then updated the index with the correct, earliest timestamp for each version, based on the current digest. (A few versions had been updated in place over time.)
```bash
for digest in $(yq '.entries."k8s-gateway"[].digest' index.yaml); do
  sha=$(git log --format=format:%H -S$digest index.yaml)
  timestamp=$(git show $sha:index.yaml | yq -r '.entries."k8s-gateway"[] | select(.digest == "'$digest'") | .created')
  yq -i '.entries."k8s-gateway" = (.entries."k8s-gateway" | (.[] | select(.digest == "'$digest'") | .created) |= "'$timestamp'")' index.yaml
done

ruby -r yaml -e "y = YAML.load_file('index.yaml'); File.write('index.yaml', y.to_yaml)"
```