### PR TITLE
feature(add customLabels, tolerations, topologySpreadConstraints and service.useTcp values)

### DIFF
--- a/charts/k8s-gateway/Chart.yaml
+++ b/charts/k8s-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-gateway
 description: A Helm chart for the k8s_gateway CoreDNS plugin
 type: application
-version: 2.3.0
+version: 2.4.0
 appVersion: 0.4.0
 maintainers:
   - email: mmkashin@gmail.com

--- a/charts/k8s-gateway/README.md
+++ b/charts/k8s-gateway/README.md
@@ -9,6 +9,7 @@ The following table lists the configurable parameters of the k8s_gateway chart a
 | Parameter                        | Description                                                                               | Default               |
 | -------------------------------- | ----------------------------------------------------------------------------------------- | --------------------- |
 | `domain`                         | Delegated domain(s)                                                                       |                       |
+| `customLabels`                   | Labels to apply to all resources                                                          | `{}`                  |
 | `watchedResources`               | Limit what kind of resources to watch, e.g. `watchedResources: ["Ingress"]`               | `[]`                  |
 | `fallthrough.enabled`            | Enable fallthrough support                                                                | `false`               |
 | `fallthrough.zones`              | List of zones to enable fallthrough on                                                    | `[]`                  |
@@ -21,6 +22,8 @@ The following table lists the configurable parameters of the k8s_gateway chart a
 | `image.tag`                      | Image tag                                                                                 | `latest`              |
 | `image.pullPolicy`               | Image pull policy                                                                         | `Always`              |
 | `nodeSelector`                   | Node labels for pod assignment                                                            | `{}`                  |
+| `tolerations`                    | Use to schedule on node taint to be not schedulable                                       | `[]`                  |
+| `topologySpreadConstraints`      | Use topology spread constraints to control how Pods are spread across your cluster        | `[]`                  |
 | `affinity`                       | Pod affinity                                                                              | `{}`                  |
 | `resources`                      | Pod resource requests & limits                                                            | `{}`                  |
 | `serviceAccount.create`          | Create ServiceAccount                                                                     | `true`                |
@@ -30,5 +33,6 @@ The following table lists the configurable parameters of the k8s_gateway chart a
 | `service.nodePort`               | Node port when service type is `NodePort`. Randomly chosen by Kubernetes if not provided  |                       |
 | `service.loadBalancerIP`         | The IP address to use when using serviceType `LoadBalancer`                               |                       |
 | `service.clusterIP`              | The IP address to use when using serviceType `ClusterIP`. Randomly chosen by Kubernetes if not provided  |        |
+| `service.useTcp`                 | set this parameter to optionally expose the port on tcp as well as udp for the DNS protocol  | `false`            |
 | `replicaCount`                   | Number of replicas                                                                        | `1`                   |
 | `zoneFiles`                      | Inject few custom zone files                                                              | `[]`                  |

--- a/charts/k8s-gateway/templates/configmap.yaml
+++ b/charts/k8s-gateway/templates/configmap.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "k8s-gateway.fullname" . }}
   labels:
     {{- include "k8s-gateway.labels" . | nindent 4 }}
+    {{- if .Values.customLabels }}
+    {{ toYaml .Values.customLabels | trim | nindent 4 }}
+    {{- end }}
 data:
   Corefile: |-
     .:1053 {

--- a/charts/k8s-gateway/templates/deployment.yaml
+++ b/charts/k8s-gateway/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "k8s-gateway.fullname" . }}
   labels:
     {{- include "k8s-gateway.labels" . | nindent 4 }}
+    {{- if .Values.customLabels }}
+    {{ toYaml .Values.customLabels | trim | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -12,14 +15,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "k8s-gateway.selectorLabels" . | nindent 8 }}
+        {{- include "k8s-gateway.labels" . | nindent 8 }}
+        {{- if .Values.customLabels }}
+        {{ toYaml .Values.customLabels | trim | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ toYaml .Values | sha256sum }}
     spec:
       serviceAccountName: {{ include "k8s-gateway.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{- if .Values.image.registry }}{{ .Values.image.registry }}/{{- end }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         {{- if .Values.secure }}
@@ -35,6 +41,11 @@ spec:
         - containerPort: 1053
           name: dns-udp
           protocol: UDP
+        {{- if (eq .Values.service.useTcp true) }}
+        - containerPort: 1053
+          name: dns-tcp
+          protocol: TCP
+        {{- end }}
         {{- range .Values.extraZonePlugins | uniq }}
         {{- if eq .name "prometheus" }}
         - containerPort: {{ .parameters | regexFind "[^\\:]*$" }}
@@ -73,6 +84,14 @@ spec:
             {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}

--- a/charts/k8s-gateway/templates/rbac.yaml
+++ b/charts/k8s-gateway/templates/rbac.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "k8s-gateway.fullname" . }}
   labels:
     {{- include "k8s-gateway.labels" . | nindent 4 }}
+    {{- if .Values.customLabels }}
+    {{ toYaml .Values.customLabels | trim | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - ""
@@ -34,7 +37,10 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "k8s-gateway.fullname" . }}
   labels:
-  {{- include "k8s-gateway.labels" . | nindent 4 }}
+    {{- include "k8s-gateway.labels" . | nindent 4 }}
+    {{- if .Values.customLabels }}
+    {{ toYaml .Values.customLabels | trim | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/k8s-gateway/templates/service.yaml
+++ b/charts/k8s-gateway/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- toYaml .Values.service.labels | nindent 4 }}
 {{- end }}
     {{- include "k8s-gateway.labels" . | nindent 4 }}
+    {{- if .Values.customLabels }}
+    {{ toYaml .Values.customLabels | trim | nindent 4 }}
+    {{- end }}
   annotations:
 {{- if .Values.service.annotations }}
     {{- toYaml .Values.service.annotations | nindent 4 }}
@@ -31,6 +34,15 @@ spec:
     {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
+  {{- if (eq .Values.service.useTcp true) }}
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    name: dns-tcp
+    targetPort: dns-tcp
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+  {{- end }}
   {{- if not (empty .Values.service.externalTrafficPolicy)}}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}

--- a/charts/k8s-gateway/templates/serviceaccount.yaml
+++ b/charts/k8s-gateway/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "k8s-gateway.serviceAccountName" . }}
   labels:
     {{- include "k8s-gateway.labels" . | nindent 4 }}
+    {{- if .Values.customLabels }}
+    {{ toYaml .Values.customLabels | trim | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/k8s-gateway/values.yaml
+++ b/charts/k8s-gateway/values.yaml
@@ -7,6 +7,9 @@ image:
 # Delegated domain
 domain: ""
 
+# Labels to apply to all resources
+customLabels: {}
+
 # TTL for non-apex responses (in seconds)
 ttl: 300
 
@@ -76,8 +79,13 @@ service:
   # ipFamilies:
   #   - IPv4
   #   - IPv6
+  useTcp: false
 
 nodeSelector: {}
+
+tolerations: []
+
+topologySpreadConstraints: []
 
 affinity: {}
 


### PR DESCRIPTION
Hello,

I need to add this feature to the current helm chart.

The customLabels value is used to add custom labels to all resources, so that they can be easily grouped with others and then retrieved using the selector label.

The toleration value is used to schedule pods on master nodes, for example.

The topologySpreadConstraints value is used to control how Pods are spread across your cluster.

The service.useTcp value is used to also enable tcp protocol on dns port.

Regards