### PR TITLE
README: Minor reference updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin relies on its own connection to the k8s API server and doesn't share
 | TLSRoute<sup>[1](#foot1) | all FQDNs from `spec.hostnames` matching configured zones | `gateway.status.addresses`<sup>[2](#foot2)</sup> |
 | GRPCRoute<sup>[1](#foot1) | all FQDNs from `spec.hostnames` matching configured zones | `gateway.status.addresses`<sup>[2](#foot2)</sup> |
 | Ingress | all FQDNs from `spec.rules[*].host` matching configured zones | `.status.loadBalancer.ingress` |
-| Service<sup>[3](#foot3)</sup> | `name.namespace` + any of the configured zones OR any string consisting of lower case alphanumeric characters, '-' or '.', specified in the `coredns.io/hostname` or `external-dns.alpha.kubernetes.io/hostname` annotations (see [this](https://github.com/ori-edge/k8s_gateway/blob/master/test/service-annotation.yml#L8) for an example) | `.status.loadBalancer.ingress` |
+| Service<sup>[3](#foot3)</sup> | `name.namespace` + any of the configured zones OR any string consisting of lower case alphanumeric characters, '-' or '.', specified in the `coredns.io/hostname` or `external-dns.alpha.kubernetes.io/hostname` annotations (see [this](https://github.com/ori-edge/k8s_gateway/blob/master/test/single-stack/service-annotation.yml#L8) for an example) | `.status.loadBalancer.ingress` |
 | VirtualServer<sup>[4](#foot4)</sup> | `spec.host` | `.status.externalEnpoints.ip` |
 
 
@@ -182,7 +182,7 @@ Some test resources can be added to the k8s cluster with:
 
 ```
 # ingress and service resources
-kubectl apply -f ./test/ingress-services.yml
+kubectl apply -f ./test/single-stack/ingress-services.yml
 
 # gateway API resources
 kubectl apply -f ./test/gateway-api/resources.yml


### PR DESCRIPTION
I was reading the docs earlier and noticed a couple stale parts of the readme which must of come from some previous moves.

- Fix a link to the service annotations.
- Update local test path reference.