### PR TITLE
Fix external-dns spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,16 @@ REGISTRY ?= quay.io/oriedge
 IMG ?= $(REGISTRY)/$(BIN)
 
 setup:
-	./test/kind-with-registry.sh 
+	./test/kind-with-registry.sh
 
-up: 
+up:
 	tilt up
 
 down:
 	tilt down
 
-nuke: 
-	./test/teardown-kind-with-registry.sh 
+nuke:
+	./test/teardown-kind-with-registry.sh
 
 ## Build the plugin binary
 build:

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -417,15 +417,22 @@ func serviceHostnameIndexFunc(obj interface{}) ([]string, error) {
 	}
 
 	hostname := service.Name + "." + service.Namespace
+	hostnames := []string{}
 	if annotation, exists := checkServiceAnnotation(hostnameAnnotationKey, service); exists {
-		hostname = annotation
+		hostnames = []string{annotation}
 	} else if annotation, exists := checkServiceAnnotation(externalDnsHostnameAnnotationKey, service); exists {
-		hostname = annotation
+		hostnames = splitHostnameAnnotation(annotation)
+	} else {
+		hostnames = []string{hostname}
 	}
 
 	log.Debugf("Adding index %s for service %s", hostname, service.Name)
 
-	return []string{hostname}, nil
+	return hostnames, nil
+}
+
+func splitHostnameAnnotation(annotation string) []string {
+	return strings.Split(strings.ReplaceAll(annotation, " ", ""), ",")
 }
 
 func checkServiceAnnotation(annotation string, service *core.Service) (string, bool) {

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -421,18 +421,18 @@ func serviceHostnameIndexFunc(obj interface{}) ([]string, error) {
 	if annotation, exists := checkServiceAnnotation(hostnameAnnotationKey, service); exists {
 		if checkDomainValid(annotation) {
 			hostnames = []string{annotation}
+			log.Debugf("Adding index %s for service %s", annotation, service.Name)
 		}
 	} else if annotation, exists := checkServiceAnnotation(externalDnsHostnameAnnotationKey, service); exists {
 		for _, hostname := range splitHostnameAnnotation(annotation) {
 			if checkDomainValid(hostname) {
 				hostnames = append(hostnames, hostname)
+				log.Debugf("Adding index %s for service %s", hostname, service.Name)
 			}
 		}
 	} else {
 		hostnames = []string{hostname}
 	}
-
-	log.Debugf("Adding index %s for service %s", hostname, service.Name)
 
 	return hostnames, nil
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/test"
@@ -56,8 +57,11 @@ func TestController(t *testing.T) {
 
 	for index, testObj := range testServices {
 		found, _ := serviceHostnameIndexFunc(testObj)
-		if !isFound(index, found) {
-			t.Errorf("Service key %s not found in index: %v", index, found)
+		indices := strings.Split(index, ",")
+		for _, idx := range indices {
+			if !isFound(strings.TrimSpace(idx), found) {
+				t.Errorf("Service key %s not found in index: %v", idx, found)
+			}
 		}
 		ips := fetchServiceLoadBalancerIPs(testObj.Status.LoadBalancer.Ingress)
 		if len(ips) != 1 {
@@ -265,6 +269,44 @@ var testServices = map[string]*core.Service{
 			Namespace: "ns1",
 			Annotations: map[string]string{
 				"coredns.io/hostname": "annotation",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.3"},
+				},
+			},
+		},
+	},
+	"annotation-external-dns": {
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc3",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Type: core.ServiceTypeLoadBalancer,
+		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{
+					{IP: "192.0.0.3"},
+				},
+			},
+		},
+	},
+	"annotation-external-dns-list1,annotation-external-dns-list2": {
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc3",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "annotation-external-dns-list1,annotation-external-dns-list2",
 			},
 		},
 		Spec: core.ServiceSpec{


### PR DESCRIPTION
### Issue
External DNS allows for comma separated domains in its spec.

https://github.com/kubernetes-sigs/external-dns/blob/master/docs/annotations/annotations.md#external-dnsalphakubernetesiohostname

This however does not.

### Changes
* Allows for comma separated domains from external-dns
* Separated the check for annotation and domain validation to support multiple domains more gracefully

### Testing
* We are currently using this as is, however you can test by providing the external-dns annotation a comma separated list and checking the logs on the pod.